### PR TITLE
feat: remove context from adapters and pass it by parameter

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -10,7 +10,9 @@ import { Wallet } from "./supabase/helpers/tables/wallet";
 import { Database } from "./supabase/types";
 import { env } from "../bindings/env";
 
-const supabaseClient = createClient<Database>(env.SUPABASE_URL, env.SUPABASE_KEY, { auth: { persistSession: false } });
+export const supabaseClient = createClient<Database>(env.SUPABASE_URL, env.SUPABASE_KEY, {
+  auth: { persistSession: false },
+});
 
 export function createAdapters() {
   return {
@@ -21,7 +23,7 @@ export function createAdapters() {
       debit: new Settlement(supabaseClient),
       settlement: new Settlement(supabaseClient),
       label: new Label(supabaseClient),
-      logs: new Logs(supabaseClient, env.LOG_ENVIRONMENT, env.LOG_RETRY_LIMIT, env.LOG_LEVEL),
+      logs: new Logs(supabaseClient, null, env.LOG_ENVIRONMENT, env.LOG_RETRY_LIMIT, env.LOG_LEVEL),
       locations: new Locations(supabaseClient),
       super: new Super(supabaseClient),
     },

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,5 +1,4 @@
 import { createClient } from "@supabase/supabase-js";
-import { Context as ProbotContext } from "probot";
 import { Access } from "./supabase/helpers/tables/access";
 import { Label } from "./supabase/helpers/tables/label";
 import { Locations } from "./supabase/helpers/tables/locations";
@@ -13,18 +12,18 @@ import { env } from "../bindings/env";
 
 const supabaseClient = createClient<Database>(env.SUPABASE_URL, env.SUPABASE_KEY, { auth: { persistSession: false } });
 
-export function createAdapters(context: ProbotContext) {
+export function createAdapters() {
   return {
     supabase: {
-      access: new Access(supabaseClient, context),
-      wallet: new Wallet(supabaseClient, context),
-      user: new User(supabaseClient, context),
-      debit: new Settlement(supabaseClient, context),
-      settlement: new Settlement(supabaseClient, context),
-      label: new Label(supabaseClient, context),
-      logs: new Logs(supabaseClient, context, env.LOG_ENVIRONMENT, env.LOG_RETRY_LIMIT, env.LOG_LEVEL),
-      locations: new Locations(supabaseClient, context),
-      super: new Super(supabaseClient, context),
+      access: new Access(supabaseClient),
+      wallet: new Wallet(supabaseClient),
+      user: new User(supabaseClient),
+      debit: new Settlement(supabaseClient),
+      settlement: new Settlement(supabaseClient),
+      label: new Label(supabaseClient),
+      logs: new Logs(supabaseClient, env.LOG_ENVIRONMENT, env.LOG_RETRY_LIMIT, env.LOG_LEVEL),
+      locations: new Locations(supabaseClient),
+      super: new Super(supabaseClient),
     },
   };
 }

--- a/src/adapters/supabase/helpers/tables/access.ts
+++ b/src/adapters/supabase/helpers/tables/access.ts
@@ -26,7 +26,7 @@ export class Access extends Super {
     const { data, error } = await this.supabase.from("access").select("*, users(*)").filter("id", "eq", id);
 
     if (error) {
-      this.runtime.logger.error(null, error.message, error);
+      this.runtime.logger.error(error.message, error);
       throw new Error(error.message);
     }
     return data;
@@ -35,7 +35,7 @@ export class Access extends Super {
   public async getAccess(id: number): Promise<AccessRow | null> {
     const userWithAccess = await this._getUserWithAccess(id);
     if (userWithAccess[0]?.access === undefined) {
-      this.runtime.logger.debug(null, "Access is undefined");
+      this.runtime.logger.debug("Access is undefined");
       return null;
     }
     if (userWithAccess[0]?.access === null) throw new Error("Access is null");

--- a/src/adapters/supabase/helpers/tables/access.ts
+++ b/src/adapters/supabase/helpers/tables/access.ts
@@ -4,7 +4,6 @@ import { Database } from "../../types/database";
 import { GitHubNode } from "../client";
 import { Super } from "./super";
 import { UserRow } from "./user";
-import { Context as ProbotContext } from "probot";
 type AccessRow = Database["public"]["Tables"]["access"]["Row"];
 type AccessInsert = Database["public"]["Tables"]["access"]["Insert"];
 type UserWithAccess = (UserRow & { access: AccessRow | null })[];
@@ -19,15 +18,15 @@ type _Access = {
 };
 
 export class Access extends Super {
-  constructor(supabase: SupabaseClient, context: ProbotContext) {
-    super(supabase, context);
+  constructor(supabase: SupabaseClient) {
+    super(supabase);
   }
 
   private async _getUserWithAccess(id: number): Promise<UserWithAccess> {
     const { data, error } = await this.supabase.from("access").select("*, users(*)").filter("id", "eq", id);
 
     if (error) {
-      this.runtime.logger.error(error.message, error);
+      this.runtime.logger.error(null, error.message, error);
       throw new Error(error.message);
     }
     return data;
@@ -36,7 +35,7 @@ export class Access extends Super {
   public async getAccess(id: number): Promise<AccessRow | null> {
     const userWithAccess = await this._getUserWithAccess(id);
     if (userWithAccess[0]?.access === undefined) {
-      this.runtime.logger.debug("Access is undefined");
+      this.runtime.logger.debug(null, "Access is undefined");
       return null;
     }
     if (userWithAccess[0]?.access === null) throw new Error("Access is null");

--- a/src/adapters/supabase/helpers/tables/label.ts
+++ b/src/adapters/supabase/helpers/tables/label.ts
@@ -2,14 +2,13 @@ import { SupabaseClient } from "@supabase/supabase-js";
 import { Repository } from "../../../../types/payload";
 import { Database } from "../../types";
 import { Super } from "./super";
-import { Context as ProbotContext } from "probot";
 import Runtime from "../../../../bindings/bot-runtime";
 
 type LabelRow = Database["public"]["Tables"]["labels"]["Row"];
 
 export class Label extends Super {
-  constructor(supabase: SupabaseClient, context: ProbotContext) {
-    super(supabase, context);
+  constructor(supabase: SupabaseClient) {
+    super(supabase);
   }
 
   async saveLabelChange({
@@ -75,7 +74,7 @@ export class Label extends Super {
 
     if (locationError) throw new Error(locationError.message);
     if (!locationData) {
-      runtime.logger.warn("Repository location ID not found in database.");
+      runtime.logger.warn(null, "Repository location ID not found in database.");
       return null;
     }
 

--- a/src/adapters/supabase/helpers/tables/label.ts
+++ b/src/adapters/supabase/helpers/tables/label.ts
@@ -74,7 +74,7 @@ export class Label extends Super {
 
     if (locationError) throw new Error(locationError.message);
     if (!locationData) {
-      runtime.logger.warn(null, "Repository location ID not found in database.");
+      runtime.logger.warn("Repository location ID not found in database.");
       return null;
     }
 

--- a/src/adapters/supabase/helpers/tables/locations.ts
+++ b/src/adapters/supabase/helpers/tables/locations.ts
@@ -17,8 +17,8 @@ export class Locations extends Super {
   node_id: string | undefined;
   node_type: string | undefined;
 
-  constructor(supabase: SupabaseClient, context: ProbotContext) {
-    super(supabase, context);
+  constructor(supabase: SupabaseClient) {
+    super(supabase);
   }
 
   public async getLocationsFromRepo(repositoryId: number) {
@@ -27,11 +27,11 @@ export class Locations extends Super {
       .select("id")
       .eq("repository_id", repositoryId);
 
-    if (error) throw this.runtime.logger.error("Error getting location data", new Error(error.message));
+    if (error) throw this.runtime.logger.error(null, "Error getting location data", new Error(error.message));
     return locationData;
   }
 
-  public async getLocationsMetaData(issueCommentId: string) {
+  public async getLocationsMetaData(context: ProbotContext, issueCommentId: string) {
     const graphQlQuery = `
     query {
         node(id: "${issueCommentId}") {
@@ -62,7 +62,7 @@ export class Locations extends Super {
       }
     `;
 
-    this.locationResponse = (await this.context.octokit.graphql(graphQlQuery)) as LocationResponse;
+    this.locationResponse = (await context.octokit.graphql(graphQlQuery)) as LocationResponse;
     console.trace(this.locationResponse);
 
     this.user_id = this.locationResponse.data.node.author.id;

--- a/src/adapters/supabase/helpers/tables/locations.ts
+++ b/src/adapters/supabase/helpers/tables/locations.ts
@@ -27,7 +27,7 @@ export class Locations extends Super {
       .select("id")
       .eq("repository_id", repositoryId);
 
-    if (error) throw this.runtime.logger.error(null, "Error getting location data", new Error(error.message));
+    if (error) throw this.runtime.logger.error("Error getting location data", new Error(error.message));
     return locationData;
   }
 

--- a/src/adapters/supabase/helpers/tables/logs.ts
+++ b/src/adapters/supabase/helpers/tables/logs.ts
@@ -58,7 +58,7 @@ export class Logs extends Super {
     // - the comment to post on github (must include diff syntax)
     // - the comment to post on the console (must be colorized)
 
-    consoleLog(logMessage, metadata || null);
+    consoleLog(logMessage, metadata || undefined);
 
     if (context && postComment) {
       const colorizedCommentMessage = this._diffColorCommentMessage(type, logMessage);

--- a/src/adapters/supabase/helpers/tables/settlement.ts
+++ b/src/adapters/supabase/helpers/tables/settlement.ts
@@ -3,7 +3,6 @@ import Decimal from "decimal.js";
 import { Comment, Payload } from "../../../../types/payload";
 import { Database } from "../../types/database";
 import { Super } from "./super";
-import { Context as ProbotContext } from "probot";
 
 type DebitInsert = Database["public"]["Tables"]["debits"]["Insert"];
 type CreditInsert = Database["public"]["Tables"]["credits"]["Insert"];
@@ -26,8 +25,8 @@ type AddCreditWithPermit = {
 };
 
 export class Settlement extends Super {
-  constructor(supabase: SupabaseClient, context: ProbotContext) {
-    super(supabase, context);
+  constructor(supabase: SupabaseClient) {
+    super(supabase);
   }
 
   private async _lookupTokenId(networkId: number, address: string): Promise<number> {

--- a/src/adapters/supabase/helpers/tables/super.ts
+++ b/src/adapters/supabase/helpers/tables/super.ts
@@ -1,15 +1,12 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import Runtime from "../../../../bindings/bot-runtime";
-import { Context as ProbotContext } from "probot";
 
 export class Super {
   protected supabase: SupabaseClient;
   protected runtime: Runtime; // convenience accessor
-  protected context: ProbotContext;
 
-  constructor(supabase: SupabaseClient, context: ProbotContext) {
+  constructor(supabase: SupabaseClient) {
     this.supabase = supabase;
     this.runtime = Runtime.getState();
-    this.context = context;
   }
 }

--- a/src/adapters/supabase/helpers/tables/user.ts
+++ b/src/adapters/supabase/helpers/tables/user.ts
@@ -5,13 +5,12 @@ import { Context as ProbotContext } from "probot";
 
 export type UserRow = Database["public"]["Tables"]["users"]["Row"];
 export class User extends Super {
-  constructor(supabase: SupabaseClient, context: ProbotContext) {
-    super(supabase, context);
+  constructor(supabase: SupabaseClient) {
+    super(supabase);
   }
 
-  public async getUserId(username: string): Promise<number> {
-    const octokit = this.context.octokit;
-    const { data } = await octokit.rest.users.getByUsername({ username });
+  public async getUserId(context: ProbotContext, username: string): Promise<number> {
+    const { data } = await context.octokit.rest.users.getByUsername({ username });
     return data.id;
   }
 
@@ -39,7 +38,7 @@ export class User extends Super {
       .eq("user_id", userId)
       .order("id", { ascending: false }) // get the latest one
       .maybeSingle();
-    if (accessError) throw this.runtime.logger.error("Error getting access data", accessError);
+    if (accessError) throw this.runtime.logger.error(null, "Error getting access data", accessError);
     return accessData;
   }
 }

--- a/src/adapters/supabase/helpers/tables/user.ts
+++ b/src/adapters/supabase/helpers/tables/user.ts
@@ -38,7 +38,7 @@ export class User extends Super {
       .eq("user_id", userId)
       .order("id", { ascending: false }) // get the latest one
       .maybeSingle();
-    if (accessError) throw this.runtime.logger.error(null, "Error getting access data", accessError);
+    if (accessError) throw this.runtime.logger.error("Error getting access data", accessError);
     return accessData;
   }
 }

--- a/src/adapters/supabase/helpers/tables/wallet.test.ts
+++ b/src/adapters/supabase/helpers/tables/wallet.test.ts
@@ -1,7 +1,6 @@
 import dotenv from "dotenv";
 dotenv.config();
 
-import { Context as ProbotContext } from "probot";
 import { createAdapters } from "../../..";
 import { User } from "../../../../types";
 const SUPABASE_URL = process.env.SUPABASE_URL;
@@ -9,10 +8,8 @@ if (!SUPABASE_URL) throw new Error("SUPABASE_URL is not defined");
 const SUPABASE_KEY = process.env.SUPABASE_KEY;
 if (!SUPABASE_KEY) throw new Error("SUPABASE_KEY is not defined");
 
-const mockContext = { supabase: { url: SUPABASE_URL, key: SUPABASE_KEY } } as unknown as ProbotContext;
-
-async function getWalletAddressAndUrlTest(eventContext: ProbotContext) {
-  const { wallet } = createAdapters(eventContext).supabase;
+async function getWalletAddressAndUrlTest() {
+  const { wallet } = createAdapters().supabase;
   const userId = 4975670 as User["id"];
   const results = [] as unknown[];
   try {
@@ -26,4 +23,4 @@ async function getWalletAddressAndUrlTest(eventContext: ProbotContext) {
   console.trace(results);
 }
 
-void getWalletAddressAndUrlTest(mockContext);
+void getWalletAddressAndUrlTest();

--- a/src/adapters/supabase/helpers/tables/wallet.ts
+++ b/src/adapters/supabase/helpers/tables/wallet.ts
@@ -183,7 +183,7 @@ export class Wallet extends Super {
   private async _enrichLocationMetaData(walletData: WalletRow, locationMetaData: LocationMetaData) {
     const runtime = Runtime.getState();
     const logger = runtime.logger;
-    logger.ok(null, "Enriching wallet location metadata", locationMetaData);
+    logger.ok("Enriching wallet location metadata", locationMetaData);
     return await this.supabase.from("locations").update(locationMetaData).eq("id", walletData.location_id);
   }
 }

--- a/src/adapters/supabase/helpers/tables/wallet.ts
+++ b/src/adapters/supabase/helpers/tables/wallet.ts
@@ -16,8 +16,8 @@ type IssueCommentPayload =
   | ProbotContext<"issue_comment.edited">["payload"];
 
 export class Wallet extends Super {
-  constructor(supabase: SupabaseClient, context: ProbotContext) {
-    super(supabase, context);
+  constructor(supabase: SupabaseClient) {
+    super(supabase);
   }
 
   public async getAddress(id: number): Promise<string> {
@@ -25,8 +25,8 @@ export class Wallet extends Super {
     return this._validateAndGetWalletAddress(userWithWallet);
   }
 
-  public async upsertWalletAddress(address: string) {
-    const payload = this.context.payload as
+  public async upsertWalletAddress(context: ProbotContext, address: string) {
+    const payload = context.payload as
       | ProbotContext<"issue_comment.created">["payload"]
       | ProbotContext<"issue_comment.edited">["payload"];
 
@@ -183,7 +183,7 @@ export class Wallet extends Super {
   private async _enrichLocationMetaData(walletData: WalletRow, locationMetaData: LocationMetaData) {
     const runtime = Runtime.getState();
     const logger = runtime.logger;
-    logger.ok("Enriching wallet location metadata", locationMetaData);
+    logger.ok(null, "Enriching wallet location metadata", locationMetaData);
     return await this.supabase.from("locations").update(locationMetaData).eq("id", walletData.location_id);
   }
 }

--- a/src/bindings/event.ts
+++ b/src/bindings/event.ts
@@ -33,11 +33,11 @@ type AllHandlers = PreActionHandler | MainActionHandler | PostActionHandler;
 
 const validatePayload = ajv.compile(PayloadSchema);
 
-export async function bindEvents(eventContext: ProbotContext) {
-  const runtime = Runtime.getState();
-  runtime.adapters = createAdapters();
-  runtime.logger = runtime.adapters.supabase.logs;
+const runtime = Runtime.getState();
+runtime.adapters = createAdapters();
+runtime.logger = runtime.adapters.supabase.logs;
 
+export async function bindEvents(eventContext: ProbotContext) {
   const payload = eventContext.payload as Payload;
   const eventName = payload?.action ? `${eventContext.name}.${payload?.action}` : eventContext.name; // some events wont have actions as this grows
 

--- a/src/bindings/event.ts
+++ b/src/bindings/event.ts
@@ -1,8 +1,8 @@
 import OpenAI from "openai";
 import { Context as ProbotContext } from "probot";
-import { createAdapters } from "../adapters";
+import { createAdapters, supabaseClient } from "../adapters";
 import { LogReturn } from "../adapters/supabase";
-import { LogMessage } from "../adapters/supabase/helpers/tables/logs";
+import { LogMessage, Logs } from "../adapters/supabase/helpers/tables/logs";
 import { processors, wildcardProcessors } from "../handlers/processors";
 import { validateConfigChange } from "../handlers/push";
 import structuredMetadata from "../handlers/shared/structured-metadata";
@@ -20,6 +20,7 @@ import { GitHubEvent, Payload, PayloadSchema } from "../types/payload";
 import { ajv } from "../utils/ajv";
 import { generateConfiguration } from "../utils/generate-configuration";
 import Runtime from "./bot-runtime";
+import { env } from "./env";
 
 const allowedEvents = Object.values(GitHubEvent) as string[];
 
@@ -40,12 +41,13 @@ runtime.logger = runtime.adapters.supabase.logs;
 export async function bindEvents(eventContext: ProbotContext) {
   const payload = eventContext.payload as Payload;
   const eventName = payload?.action ? `${eventContext.name}.${payload?.action}` : eventContext.name; // some events wont have actions as this grows
+  const logger = new Logs(supabaseClient, eventContext, env.LOG_ENVIRONMENT, env.LOG_RETRY_LIMIT, env.LOG_LEVEL);
 
-  runtime.logger.info(eventContext, "Event received", { id: eventContext.id, name: eventName });
+  logger.info("Event received", { id: eventContext.id, name: eventName });
 
   if (!allowedEvents.includes(eventName)) {
     // just check if its on the watch list
-    return runtime.logger.info(eventContext, `Skipping the event. reason: not configured`);
+    return logger.info(`Skipping the event. reason: not configured`);
   }
 
   // Skip validation for installation event and push
@@ -53,13 +55,13 @@ export async function bindEvents(eventContext: ProbotContext) {
     // Validate payload
     const valid = validatePayload(payload);
     if (!valid && validatePayload.errors) {
-      return runtime.logger.error(eventContext, "Payload schema validation failed!", validatePayload.errors);
+      return logger.error("Payload schema validation failed!", validatePayload.errors);
     }
 
     // Check if we should skip the event
     const should = shouldSkip(eventContext);
     if (should.stop) {
-      return runtime.logger.info(eventContext, "Skipping the event.", { reason: should.reason });
+      return logger.info("Skipping the event.", { reason: should.reason });
     }
   }
 
@@ -77,13 +79,16 @@ export async function bindEvents(eventContext: ProbotContext) {
     event: eventContext,
     config: botConfig,
     openAi: botConfig.keys.openAi ? new OpenAI({ apiKey: botConfig.keys.openAi }) : null,
+    logger: logger,
+    payload: payload,
+    octokit: eventContext.octokit,
   };
 
   if (!context.config.keys.evmPrivateEncrypted) {
-    runtime.logger.warn(eventContext, "No EVM private key found");
+    context.logger.warn("No EVM private key found");
   }
 
-  if (!runtime.logger) {
+  if (!context.logger) {
     throw new Error("Failed to create logger");
   }
 
@@ -91,7 +96,7 @@ export async function bindEvents(eventContext: ProbotContext) {
   const handlers = processors[eventName];
 
   if (!handlers) {
-    return runtime.logger.warn(eventContext, "No handler configured for event:", { eventName });
+    return context.logger.warn("No handler configured for event:", { eventName });
   }
   const { pre, action, post } = handlers;
 
@@ -105,8 +110,7 @@ export async function bindEvents(eventContext: ProbotContext) {
     // List all the function names of handlerType.actions
     const functionNames = handlerWithType.actions.map((action) => action?.name);
 
-    runtime.logger.info(
-      eventContext,
+    context.logger.info(
       `Running "${handlerWithType.type}" \
       for event: "${eventName}". \
       handlers: "${functionNames.join(", ")}"`
@@ -117,11 +121,11 @@ export async function bindEvents(eventContext: ProbotContext) {
 
   // Skip wildcard handlers for installation event and push event
   if (eventName == GitHubEvent.INSTALLATION_ADDED_EVENT || eventName == GitHubEvent.PUSH_EVENT) {
-    return runtime.logger.info(eventContext, "Skipping wildcard handlers for event:", eventName);
+    return context.logger.info("Skipping wildcard handlers for event:", eventName);
   } else {
     // Run wildcard handlers
     const functionNames = wildcardProcessors.map((action) => action?.name);
-    runtime.logger.info(eventContext, `Running wildcard handlers: "${functionNames.join(", ")}"`);
+    context.logger.info(`Running wildcard handlers: "${functionNames.join(", ")}"`);
     const wildCardHandlerType: WildCardHandlerWithType = { type: "wildcard", actions: wildcardProcessors };
     await logAnyReturnFromHandlers(context, wildCardHandlerType);
   }
@@ -138,8 +142,7 @@ async function logAnyReturnFromHandlers(context: Context, handlerType: AllHandle
         // only log main handler results
         await renderMainActionOutput(context, response, action);
       } else {
-        const runtime = Runtime.getState();
-        runtime.logger.ok(context.event, "Completed", { action: action.name, type: handlerType.type });
+        context.logger.ok("Completed", { action: action.name, type: handlerType.type });
       }
     } catch (report: unknown) {
       await renderCatchAllWithContext(report);
@@ -152,8 +155,7 @@ async function renderMainActionOutput(
   response: void | HandlerReturnValuesNoVoid,
   action: AllHandlers
 ) {
-  const runtime = Runtime.getState();
-  const payload = context.event.payload as Payload;
+  const { payload, logger } = context;
   const issueNumber = payload.issue?.number;
   if (!issueNumber) {
     throw new Error("No issue number found");
@@ -174,10 +176,9 @@ async function renderMainActionOutput(
   } else if (typeof response == "string") {
     await addCommentToIssue(context, response, issueNumber);
   } else if (response === null) {
-    runtime.logger.debug(context.event, "null response", { action: action.name });
+    logger.debug("null response", { action: action.name });
   } else {
-    runtime.logger.error(
-      context.event,
+    logger.error(
       "No response from action. Ensure return of string, null, or LogReturn object",
       { action: action.name },
       true
@@ -187,11 +188,10 @@ async function renderMainActionOutput(
 
 function createRenderCatchAll(context: Context, handlerType: AllHandlersWithTypes, activeHandler: AllHandlers) {
   return async function renderCatchAll(report: LogReturn | Error | unknown) {
-    const runtime = Runtime.getState();
     const payload = context.event.payload as Payload;
     const issue = payload.issue;
     if (!issue) {
-      return runtime.logger.error(context.event, "Issue is null. Skipping", { issue });
+      return context.logger.error("Issue is null. Skipping", { issue });
     }
 
     if (report instanceof LogReturn) {
@@ -199,10 +199,7 @@ function createRenderCatchAll(context: Context, handlerType: AllHandlersWithType
       const { logMessage } = report;
 
       if (report.metadata) {
-        runtime.logger.debug(
-          context.event,
-          "this is the second place that metadata is being serialized as an html comment"
-        );
+        context.logger.debug("this is the second place that metadata is being serialized as an html comment");
         let metadataSerialized;
         const prettySerialized = JSON.stringify(report.metadata, null, 2);
         // first check if metadata is an error, then post it as a json comment
@@ -225,8 +222,7 @@ function createRenderCatchAll(context: Context, handlerType: AllHandlersWithType
         stack: report.stack,
       };
 
-      return runtime.logger.error(
-        context.event,
+      return context.logger.error(
         "action has an uncaught error",
         { logReturn: report, handlerType, activeHandler: activeHandler.name, error },
         true
@@ -242,8 +238,7 @@ function createRenderCatchAll(context: Context, handlerType: AllHandlersWithType
 
       // report as SupabaseError
 
-      return runtime.logger.error(
-        context.event,
+      return context.logger.error(
         "action returned an unexpected value",
         { logReturn: report, handlerType, activeHandler: activeHandler.name },
         true

--- a/src/handlers/access/labels-access.ts
+++ b/src/handlers/access/labels-access.ts
@@ -28,17 +28,17 @@ export async function labelAccessPermissionsCheck(context: Context) {
   const labelType = match[0].toLowerCase();
 
   if (sufficientPrivileges) {
-    logger.info("Admin and billing managers have full control over all labels", {
+    logger.info(context.event, "Admin and billing managers have full control over all labels", {
       repo: repo.full_name,
       user: sender,
       labelType,
     });
     return true;
   } else {
-    logger.info("Checking access for labels", { repo: repo.full_name, user: sender, labelType });
+    logger.info(context.event, "Checking access for labels", { repo: repo.full_name, user: sender, labelType });
     // check permission
     const { access, user } = runtime.adapters.supabase;
-    const userId = await user.getUserId(sender);
+    const userId = await user.getUserId(context.event, sender);
     const accessible = await access.getAccess(userId);
     if (accessible) {
       return true;
@@ -58,7 +58,7 @@ export async function labelAccessPermissionsCheck(context: Context) {
       `@${sender}, You are not allowed to ${eventName} ${labelName}`,
       payload.issue.number
     );
-    logger.info("No access to edit label", { sender, label: labelName });
+    logger.info(context.event, "No access to edit label", { sender, label: labelName });
     return false;
   }
 }

--- a/src/handlers/access/labels-access.ts
+++ b/src/handlers/access/labels-access.ts
@@ -1,16 +1,15 @@
 import Runtime from "../../bindings/bot-runtime";
 import { addCommentToIssue, isUserAdminOrBillingManager, removeLabel, addLabelToIssue } from "../../helpers";
-import { Context, Payload, UserType } from "../../types";
+import { Context, UserType } from "../../types";
 
 export async function labelAccessPermissionsCheck(context: Context) {
   const runtime = Runtime.getState();
-  const logger = runtime.logger;
+  const { logger, payload } = context;
   const {
     features: { publicAccessControl },
   } = context.config;
   if (!publicAccessControl.setLabel) return true;
 
-  const payload = context.event.payload as Payload;
   if (!payload.issue) return;
   if (!payload.label?.name) return;
   if (payload.sender.type === UserType.Bot) return true;
@@ -28,14 +27,14 @@ export async function labelAccessPermissionsCheck(context: Context) {
   const labelType = match[0].toLowerCase();
 
   if (sufficientPrivileges) {
-    logger.info(context.event, "Admin and billing managers have full control over all labels", {
+    logger.info("Admin and billing managers have full control over all labels", {
       repo: repo.full_name,
       user: sender,
       labelType,
     });
     return true;
   } else {
-    logger.info(context.event, "Checking access for labels", { repo: repo.full_name, user: sender, labelType });
+    logger.info("Checking access for labels", { repo: repo.full_name, user: sender, labelType });
     // check permission
     const { access, user } = runtime.adapters.supabase;
     const userId = await user.getUserId(context.event, sender);
@@ -58,7 +57,7 @@ export async function labelAccessPermissionsCheck(context: Context) {
       `@${sender}, You are not allowed to ${eventName} ${labelName}`,
       payload.issue.number
     );
-    logger.info(context.event, "No access to edit label", { sender, label: labelName });
+    logger.info("No access to edit label", { sender, label: labelName });
     return false;
   }
 }

--- a/src/handlers/assign/action.ts
+++ b/src/handlers/assign/action.ts
@@ -9,14 +9,14 @@ export async function startCommandHandler(context: Context) {
   const logger = runtime.logger;
   const payload = context.event.payload as Payload;
   if (!payload.issue) {
-    return logger.error("Issue is not defined");
+    return logger.error(context.event, "Issue is not defined");
   }
 
   const assignees = payload.issue.assignees;
 
   // If no valid assignees exist, log a debug message and return
   if (assignees.length === 0) {
-    return logger.warn("No assignees");
+    return logger.warn(context.event, "No assignees");
   }
 
   // Flatten assignees into a string
@@ -27,7 +27,7 @@ export async function startCommandHandler(context: Context) {
 
   // If no labels exist, log a debug message and return
   if (!labels) {
-    return logger.warn(`No labels to calculate timeline`);
+    return logger.warn(context.event, `No labels to calculate timeline`);
   }
 
   // Filter out labels that match the time labels defined in the config
@@ -38,7 +38,7 @@ export async function startCommandHandler(context: Context) {
   );
 
   if (timeLabelsAssigned.length == 0) {
-    return logger.debug("No labels to calculate timeline");
+    return logger.debug(context.event, "No labels to calculate timeline");
   }
 
   // Sort labels by weight and select the one with the smallest weight
@@ -68,11 +68,11 @@ export async function startCommandHandler(context: Context) {
 
   // Format the commit message
   const commitMessage = `${flattenedAssignees} the deadline is at ${endDate.toISOString()}`;
-  logger.debug("Creating an issue comment", { commitMessage });
+  logger.debug(context.event, "Creating an issue comment", { commitMessage });
 
   // Add the commit message as a comment to the issue
   // await addCommentToIssue(commitMessage, payload.issue?.number);
-  return logger.info(commitMessage);
+  return logger.info(context.event, commitMessage);
 }
 
 export async function closePullRequestForAnIssue(context: Context) {
@@ -80,25 +80,25 @@ export async function closePullRequestForAnIssue(context: Context) {
   const logger = runtime.logger;
   const payload = context.event.payload as Payload;
   if (!payload.issue?.number) {
-    throw logger.error("Issue is not defined");
+    throw logger.error(context.event, "Issue is not defined");
   }
 
-  const linkedPullRequests = await getLinkedPullRequests({
+  const linkedPullRequests = await getLinkedPullRequests(context, {
     owner: payload.repository.owner.login,
     repository: payload.repository.name,
     issue: payload.issue.number,
   });
 
   if (!linkedPullRequests.length) {
-    return logger.info(`No linked pull requests to close`);
+    return logger.info(context.event, `No linked pull requests to close`);
   }
 
-  logger.info(`Opened prs`, linkedPullRequests);
+  logger.info(context.event, `Opened prs`, linkedPullRequests);
   let comment = `These linked pull requests are closed: `;
   for (let i = 0; i < linkedPullRequests.length; i++) {
     await closePullRequest(context, linkedPullRequests[i].number);
     comment += ` <a href="${linkedPullRequests[i].href}">#${linkedPullRequests[i].number}</a> `;
   }
-  return logger.info(comment);
+  return logger.info(context.event, comment);
   // await addCommentToIssue(comment, payload.issue.number);
 }

--- a/src/handlers/assign/auto.ts
+++ b/src/handlers/assign/auto.ts
@@ -10,7 +10,7 @@ export async function checkPullRequests(context: Context) {
   const pulls = await getAllPullRequests(context);
 
   if (pulls.length === 0) {
-    return logger.debug(`No pull requests found at this time`);
+    return logger.debug(context.event, `No pull requests found at this time`);
   }
 
   const payload = context.event.payload as Payload;
@@ -31,7 +31,7 @@ export async function checkPullRequests(context: Context) {
 
     // Newly created PULL (draft or direct) pull does have same `created_at` and `updated_at`.
     if (connectedPull?.created_at !== connectedPull?.updated_at) {
-      logger.debug("It's an updated Pull Request, reverting");
+      logger.debug(context.event, "It's an updated Pull Request, reverting");
       continue;
     }
 
@@ -45,19 +45,19 @@ export async function checkPullRequests(context: Context) {
 
     // if issue is already assigned, continue
     if (issue.assignees.length > 0) {
-      logger.debug(`Issue already assigned, ignoring...`);
+      logger.debug(context.event, `Issue already assigned, ignoring...`);
       continue;
     }
 
     const assignedUsernames = issue.assignees.map((assignee) => assignee.login);
     if (!assignedUsernames.includes(opener)) {
       await addAssignees(context, +linkedIssueNumber, [opener]);
-      logger.debug("Assigned pull request opener to issue", {
+      logger.debug(context.event, "Assigned pull request opener to issue", {
         pullRequest: pull.number,
         issue: linkedIssueNumber,
         opener,
       });
     }
   }
-  return logger.debug(`Checking pull requests done!`);
+  return logger.debug(context.event, `Checking pull requests done!`);
 }

--- a/src/handlers/comment/action.ts
+++ b/src/handlers/comment/action.ts
@@ -15,11 +15,11 @@ export async function commentCreatedOrEdited(context: Context) {
   const commentedCommand = commentParser(body);
 
   if (!comment) {
-    logger.info(`Comment is null. Skipping`);
+    logger.info(context.event, `Comment is null. Skipping`);
   }
   const issue = payload.issue;
   if (!issue) {
-    throw logger.error("Issue is null. Skipping", { issue });
+    throw logger.error(context.event, "Issue is null. Skipping", { issue });
   }
 
   if (commentedCommand) {
@@ -31,17 +31,19 @@ export async function commentCreatedOrEdited(context: Context) {
 
   if (userCommand) {
     const { id, handler } = userCommand;
-    logger.info("Running a comment handler", { id, handler: handler.name });
+    logger.info(context.event, "Running a comment handler", { id, handler: handler.name });
 
     const disabled = config.disabledCommands.some((command) => command === id.replace("/", ""));
 
     if (disabled && id !== "/help") {
-      return logger.warn("Skipping because it is disabled on this repo.", { id });
+      return logger.warn(context.event, "Skipping because it is disabled on this repo.", { id });
     }
 
     return await handler(context, body);
   } else {
     const sanitizedBody = body.replace(/<!--[\s\S]*?-->/g, "");
-    return logger.verbose("Comment event received without a recognized user command.", { sanitizedBody });
+    return logger.verbose(context.event, "Comment event received without a recognized user command.", {
+      sanitizedBody,
+    });
   }
 }

--- a/src/handlers/comment/action.ts
+++ b/src/handlers/comment/action.ts
@@ -1,12 +1,10 @@
-import Runtime from "../../bindings/bot-runtime";
 import { Comment, Payload, Context } from "../../types";
 import { commentParser, userCommands } from "./handlers";
 import { verifyFirstCommentInRepository } from "./handlers/first";
 
 export async function commentCreatedOrEdited(context: Context) {
-  const runtime = Runtime.getState(),
-    config = context.config,
-    logger = runtime.logger,
+  const config = context.config,
+    logger = context.logger,
     payload = context.event.payload as Payload;
 
   const comment = payload.comment as Comment;
@@ -15,11 +13,11 @@ export async function commentCreatedOrEdited(context: Context) {
   const commentedCommand = commentParser(body);
 
   if (!comment) {
-    logger.info(context.event, `Comment is null. Skipping`);
+    logger.info(`Comment is null. Skipping`);
   }
   const issue = payload.issue;
   if (!issue) {
-    throw logger.error(context.event, "Issue is null. Skipping", { issue });
+    throw logger.error("Issue is null. Skipping", { issue });
   }
 
   if (commentedCommand) {
@@ -31,18 +29,18 @@ export async function commentCreatedOrEdited(context: Context) {
 
   if (userCommand) {
     const { id, handler } = userCommand;
-    logger.info(context.event, "Running a comment handler", { id, handler: handler.name });
+    logger.info("Running a comment handler", { id, handler: handler.name });
 
     const disabled = config.disabledCommands.some((command) => command === id.replace("/", ""));
 
     if (disabled && id !== "/help") {
-      return logger.warn(context.event, "Skipping because it is disabled on this repo.", { id });
+      return logger.warn("Skipping because it is disabled on this repo.", { id });
     }
 
     return await handler(context, body);
   } else {
     const sanitizedBody = body.replace(/<!--[\s\S]*?-->/g, "");
-    return logger.verbose(context.event, "Comment event received without a recognized user command.", {
+    return logger.verbose("Comment event received without a recognized user command.", {
       sanitizedBody,
     });
   }

--- a/src/handlers/comment/handlers/ask.ts
+++ b/src/handlers/comment/handlers/ask.ts
@@ -38,7 +38,7 @@ export async function ask(context: Context, body: string) {
     const commentsRaw = await getAllIssueComments(context, issue.number, "raw");
 
     if (!comments) {
-      throw logger.error(`Error getting issue comments`);
+      throw logger.error(context.event, `Error getting issue comments`);
     }
 
     // add the first comment of the issue/pull request
@@ -61,7 +61,7 @@ export async function ask(context: Context, body: string) {
     const links = await getAllLinkedIssuesAndPullsInBody(context, issue.number);
 
     if (typeof links === "string") {
-      logger.info("Error getting linked issues or prs: ", links);
+      logger.info(context.event, "Error getting linked issues or prs: ", links);
     } else {
       linkedIssueStreamlined = links.linkedIssues;
       linkedPRStreamlined = links.linkedPrs;
@@ -117,9 +117,9 @@ export async function ask(context: Context, body: string) {
     } else if (gptResponse.answer) {
       return gptResponse.answer;
     } else {
-      throw logger.error("Error getting response from OpenAI");
+      throw logger.error(context.event, "Error getting response from OpenAI");
     }
   } else {
-    return logger.warn("Invalid syntax for ask. usage: '/ask What is pi?'");
+    return logger.warn(context.event, "Invalid syntax for ask. usage: '/ask What is pi?'");
   }
 }

--- a/src/handlers/comment/handlers/ask.ts
+++ b/src/handlers/comment/handlers/ask.ts
@@ -1,4 +1,3 @@
-import Runtime from "../../../bindings/bot-runtime";
 import { Context, Payload, StreamlinedComment, UserType } from "../../../types";
 import { getAllIssueComments, getAllLinkedIssuesAndPullsInBody } from "../../../helpers";
 import { CreateChatCompletionRequestMessage } from "openai/resources/chat";
@@ -6,8 +5,7 @@ import { askGPT, decideContextGPT, sysMsg } from "../../../helpers/gpt";
 
 export async function ask(context: Context, body: string) {
   // The question to ask
-  const runtime = Runtime.getState();
-  const logger = runtime.logger;
+  const logger = context.logger;
 
   const payload = context.event.payload as Payload;
   const sender = payload.sender.login;
@@ -38,7 +36,7 @@ export async function ask(context: Context, body: string) {
     const commentsRaw = await getAllIssueComments(context, issue.number, "raw");
 
     if (!comments) {
-      throw logger.error(context.event, `Error getting issue comments`);
+      throw logger.error(`Error getting issue comments`);
     }
 
     // add the first comment of the issue/pull request
@@ -61,7 +59,7 @@ export async function ask(context: Context, body: string) {
     const links = await getAllLinkedIssuesAndPullsInBody(context, issue.number);
 
     if (typeof links === "string") {
-      logger.info(context.event, "Error getting linked issues or prs: ", links);
+      logger.info("Error getting linked issues or prs: ", links);
     } else {
       linkedIssueStreamlined = links.linkedIssues;
       linkedPRStreamlined = links.linkedPrs;
@@ -117,9 +115,9 @@ export async function ask(context: Context, body: string) {
     } else if (gptResponse.answer) {
       return gptResponse.answer;
     } else {
-      throw logger.error(context.event, "Error getting response from OpenAI");
+      throw logger.error("Error getting response from OpenAI");
     }
   } else {
-    return logger.warn(context.event, "Invalid syntax for ask. usage: '/ask What is pi?'");
+    return logger.warn("Invalid syntax for ask. usage: '/ask What is pi?'");
   }
 }

--- a/src/handlers/comment/handlers/assign/generate-assignment-comment.ts
+++ b/src/handlers/comment/handlers/assign/generate-assignment-comment.ts
@@ -1,5 +1,5 @@
 import Runtime from "../../../../bindings/bot-runtime";
-import { Payload } from "../../../../types";
+import { Context, Payload } from "../../../../types";
 
 const options: Intl.DateTimeFormatOptions = {
   weekday: "short",
@@ -11,7 +11,7 @@ const options: Intl.DateTimeFormatOptions = {
   timeZoneName: "short",
 };
 
-export async function generateAssignmentComment(payload: Payload, duration: number | null = null) {
+export async function generateAssignmentComment(context: Context, payload: Payload, duration: number | null = null) {
   const runtime = Runtime.getState();
   const startTime = new Date().getTime();
   let endTime: null | Date = null;
@@ -24,7 +24,7 @@ export async function generateAssignmentComment(payload: Payload, duration: numb
   const issueCreationTime = payload.issue?.created_at;
   if (!issueCreationTime) {
     const logger = Runtime.getState().logger;
-    throw logger.error("Issue creation time is not defined");
+    throw logger.error(context.event, "Issue creation time is not defined");
   }
 
   return {

--- a/src/handlers/comment/handlers/assign/generate-assignment-comment.ts
+++ b/src/handlers/comment/handlers/assign/generate-assignment-comment.ts
@@ -23,8 +23,7 @@ export async function generateAssignmentComment(context: Context, payload: Paylo
 
   const issueCreationTime = payload.issue?.created_at;
   if (!issueCreationTime) {
-    const logger = Runtime.getState().logger;
-    throw logger.error(context.event, "Issue creation time is not defined");
+    throw context.logger.error("Issue creation time is not defined");
   }
 
   return {

--- a/src/handlers/comment/handlers/assign/get-time-labels-assigned.ts
+++ b/src/handlers/comment/handlers/assign/get-time-labels-assigned.ts
@@ -1,12 +1,12 @@
 import Runtime from "../../../../bindings/bot-runtime";
-import { BotConfig, Label, Payload } from "../../../../types";
+import { BotConfig, Context, Label, Payload } from "../../../../types";
 
-export function getTimeLabelsAssigned(payload: Payload, config: BotConfig) {
+export function getTimeLabelsAssigned(context: Context, payload: Payload, config: BotConfig) {
   const runtime = Runtime.getState();
   const logger = runtime.logger;
   const labels = payload.issue?.labels;
   if (!labels?.length) {
-    logger.warn("Skipping '/start' since no labels are set to calculate the timeline", { labels });
+    logger.warn(context.event, "Skipping '/start' since no labels are set to calculate the timeline", { labels });
     return;
   }
   const timeLabelsDefined = config.labels.time;

--- a/src/handlers/comment/handlers/assign/get-time-labels-assigned.ts
+++ b/src/handlers/comment/handlers/assign/get-time-labels-assigned.ts
@@ -1,12 +1,10 @@
-import Runtime from "../../../../bindings/bot-runtime";
 import { BotConfig, Context, Label, Payload } from "../../../../types";
 
 export function getTimeLabelsAssigned(context: Context, payload: Payload, config: BotConfig) {
-  const runtime = Runtime.getState();
-  const logger = runtime.logger;
+  const logger = context.logger;
   const labels = payload.issue?.labels;
   if (!labels?.length) {
-    logger.warn(context.event, "Skipping '/start' since no labels are set to calculate the timeline", { labels });
+    logger.warn("Skipping '/start' since no labels are set to calculate the timeline", { labels });
     return;
   }
   const timeLabelsDefined = config.labels.time;

--- a/src/handlers/comment/handlers/assign/index.ts
+++ b/src/handlers/comment/handlers/assign/index.ts
@@ -1,4 +1,3 @@
-import Runtime from "../../../../bindings/bot-runtime";
 import {
   addAssignees,
   calculateDurations,
@@ -15,8 +14,7 @@ import { getMultiplierInfoToDisplay } from "./get-multiplier-info-to-display";
 import { getTimeLabelsAssigned } from "./get-time-labels-assigned";
 
 export async function assign(context: Context, body: string) {
-  const runtime = Runtime.getState();
-  const logger = runtime.logger;
+  const logger = context.logger;
   const config = context.config;
   const payload = context.event.payload as Payload;
   const issue = payload.issue;
@@ -28,48 +26,46 @@ export async function assign(context: Context, body: string) {
 
   const startDisabled = disabledCommands.some((command) => command === "start");
 
-  logger.info(context.event, "Received '/start' command", { sender: payload.sender.login, body });
+  logger.info("Received '/start' command", { sender: payload.sender.login, body });
 
   if (!issue) {
-    throw logger.warn(context.event, `Skipping '/start' because of no issue instance`);
+    throw logger.warn(`Skipping '/start' because of no issue instance`);
   }
 
   if (startDisabled) {
-    throw logger.warn(context.event, "The `/assign` command is disabled for this repository.");
+    throw logger.warn("The `/assign` command is disabled for this repository.");
   }
 
   if (issue.body && isParentIssue(issue.body)) {
     throw logger.warn(
-      context.event,
       "Please select a child issue from the specification checklist to work on. The '/start' command is disabled on parent issues."
     );
   }
 
   const openedPullRequests = await getAvailableOpenedPullRequests(context, payload.sender.login);
   logger.info(
-    context.event,
     `Opened Pull Requests with approved reviews or with no reviews but over 24 hours have passed: ${JSON.stringify(
       openedPullRequests
     )}`
   );
 
   const assignedIssues = await getAssignedIssues(context, payload.sender.login);
-  logger.info(context.event, "Max issue allowed is", maxConcurrentTasks);
+  logger.info("Max issue allowed is", maxConcurrentTasks);
 
   // check for max and enforce max
   if (assignedIssues.length - openedPullRequests.length >= maxConcurrentTasks) {
-    throw logger.warn(context.event, "Too many assigned issues, you have reached your max limit", {
+    throw logger.warn("Too many assigned issues, you have reached your max limit", {
       maxConcurrentTasks,
     });
   }
 
   if (issue.state == IssueType.CLOSED) {
-    throw logger.warn(context.event, "Skipping '/start' since the issue is closed");
+    throw logger.warn("Skipping '/start' since the issue is closed");
   }
   const assignees: User[] = (payload.issue?.assignees ?? []).filter(Boolean) as User[];
 
   if (assignees.length !== 0) {
-    throw logger.warn(context.event, "Skipping '/start' since the issue is already assigned");
+    throw logger.warn("Skipping '/start' since the issue is already assigned");
   }
 
   // ==== preamble checks completed ==== //
@@ -79,11 +75,7 @@ export async function assign(context: Context, body: string) {
 
   let duration: number | null = null;
   if (!priceLabel) {
-    throw logger.warn(
-      context.event,
-      "No price label is set, so this is not ready to be self assigned yet.",
-      priceLabel
-    );
+    throw logger.warn("No price label is set, so this is not ready to be self assigned yet.", priceLabel);
   } else {
     const timeLabelsAssigned = getTimeLabelsAssigned(context, payload, config);
     if (timeLabelsAssigned) {
@@ -95,14 +87,14 @@ export async function assign(context: Context, body: string) {
   const metadata = structuredMetadata.create("Assignment", { duration, priceLabel });
 
   if (!assignees.map((i) => i.login).includes(payload.sender.login)) {
-    logger.info(context.event, "Adding the assignee", { assignee: payload.sender.login });
+    logger.info("Adding the assignee", { assignee: payload.sender.login });
     await addAssignees(context, issue.number, [payload.sender.login]);
   }
 
   const isTaskStale = checkTaskStale(taskStaleTimeoutDuration, issue);
 
   // double check whether the assign message has been already posted or not
-  logger.info(context.event, "Creating an issue comment", { comment });
+  logger.info("Creating an issue comment", { comment });
 
   const {
     multiplierAmount: multiplierAmount,

--- a/src/handlers/comment/handlers/authorize.ts
+++ b/src/handlers/comment/handlers/authorize.ts
@@ -6,15 +6,15 @@ import { taskPaymentMetaData } from "../../wildcard";
 export async function authorizeLabelChanges(context: Context) {
   const runtime = Runtime.getState();
   const { label } = runtime.adapters.supabase;
-  const logger = runtime.logger;
+  const logger = context.logger;
   const payload = context.event.payload as Payload;
   const sender = payload.sender.login;
 
-  logger.info(context.event, "Running '/authorize' command handler", { sender });
+  logger.info("Running '/authorize' command handler", { sender });
 
   const { issue, repository } = payload;
   if (!issue) {
-    return logger.info(context.event, `Skipping '/authorize' because of no issue instance`);
+    return logger.info(`Skipping '/authorize' because of no issue instance`);
   }
 
   // check if sender is admin
@@ -23,8 +23,7 @@ export async function authorizeLabelChanges(context: Context) {
 
   // if sender is not admin, return
   if (sufficientPrivileges) {
-    throw runtime.logger.error(
-      context.event,
+    throw logger.error(
       "User is not an admin/billing_manager and do not have the required permissions to access this function.",
       { sender }
     );
@@ -33,7 +32,7 @@ export async function authorizeLabelChanges(context: Context) {
   const task = taskPaymentMetaData(context, issue);
 
   if (!task.priceLabel || !task.priorityLabel || !task.timeLabel) {
-    throw runtime.logger.error(context.event, "Missing required labels", { issueDetailed: task });
+    throw logger.error("Missing required labels", { issueDetailed: task });
   }
 
   // get current repository node id from payload and pass it to getLabelChanges function to get label changes
@@ -43,9 +42,9 @@ export async function authorizeLabelChanges(context: Context) {
     // Approve label changes
     labelChanges.forEach(async (labelChange) => {
       await label.approveLabelChange(labelChange.id);
-      return logger.info(context.event, "Approved label change", { labelChange });
+      return logger.info("Approved label change", { labelChange });
     });
   }
 
-  return runtime.logger.ok(context.event, "Label change has been approved, permit can now be generated");
+  return logger.ok("Label change has been approved, permit can now be generated");
 }

--- a/src/handlers/comment/handlers/authorize.ts
+++ b/src/handlers/comment/handlers/authorize.ts
@@ -10,11 +10,11 @@ export async function authorizeLabelChanges(context: Context) {
   const payload = context.event.payload as Payload;
   const sender = payload.sender.login;
 
-  logger.info("Running '/authorize' command handler", { sender });
+  logger.info(context.event, "Running '/authorize' command handler", { sender });
 
   const { issue, repository } = payload;
   if (!issue) {
-    return logger.info(`Skipping '/authorize' because of no issue instance`);
+    return logger.info(context.event, `Skipping '/authorize' because of no issue instance`);
   }
 
   // check if sender is admin
@@ -24,6 +24,7 @@ export async function authorizeLabelChanges(context: Context) {
   // if sender is not admin, return
   if (sufficientPrivileges) {
     throw runtime.logger.error(
+      context.event,
       "User is not an admin/billing_manager and do not have the required permissions to access this function.",
       { sender }
     );
@@ -32,7 +33,7 @@ export async function authorizeLabelChanges(context: Context) {
   const task = taskPaymentMetaData(context, issue);
 
   if (!task.priceLabel || !task.priorityLabel || !task.timeLabel) {
-    throw runtime.logger.error("Missing required labels", { issueDetailed: task });
+    throw runtime.logger.error(context.event, "Missing required labels", { issueDetailed: task });
   }
 
   // get current repository node id from payload and pass it to getLabelChanges function to get label changes
@@ -42,9 +43,9 @@ export async function authorizeLabelChanges(context: Context) {
     // Approve label changes
     labelChanges.forEach(async (labelChange) => {
       await label.approveLabelChange(labelChange.id);
-      return logger.info("Approved label change", { labelChange });
+      return logger.info(context.event, "Approved label change", { labelChange });
     });
   }
 
-  return runtime.logger.ok("Label change has been approved, permit can now be generated");
+  return runtime.logger.ok(context.event, "Label change has been approved, permit can now be generated");
 }

--- a/src/handlers/comment/handlers/first.ts
+++ b/src/handlers/comment/handlers/first.ts
@@ -1,12 +1,10 @@
-import Runtime from "../../../bindings/bot-runtime";
 import { Context, Payload } from "../../../types";
 import { generateHelpMenu } from "./help";
 
 export async function verifyFirstCommentInRepository(context: Context) {
-  const runtime = Runtime.getState();
   const payload = context.event.payload as Payload;
   if (!payload.issue) {
-    throw runtime.logger.error(context.event, "Issue is null. Skipping", { issue: payload.issue }, true);
+    throw context.logger.error("Issue is null. Skipping", { issue: payload.issue }, true);
   }
   const {
     features: {
@@ -36,5 +34,5 @@ export async function verifyFirstCommentInRepository(context: Context) {
       // await upsertCommentToIssue(payload.issue.number, msg, payload.action, payload.comment);
     }
   }
-  return runtime.logger.info(context.event, `Skipping first comment`);
+  return context.logger.info(`Skipping first comment`);
 }

--- a/src/handlers/comment/handlers/first.ts
+++ b/src/handlers/comment/handlers/first.ts
@@ -6,7 +6,7 @@ export async function verifyFirstCommentInRepository(context: Context) {
   const runtime = Runtime.getState();
   const payload = context.event.payload as Payload;
   if (!payload.issue) {
-    throw runtime.logger.error("Issue is null. Skipping", { issue: payload.issue }, true);
+    throw runtime.logger.error(context.event, "Issue is null. Skipping", { issue: payload.issue }, true);
   }
   const {
     features: {
@@ -36,5 +36,5 @@ export async function verifyFirstCommentInRepository(context: Context) {
       // await upsertCommentToIssue(payload.issue.number, msg, payload.action, payload.comment);
     }
   }
-  return runtime.logger.info(`Skipping first comment`);
+  return runtime.logger.info(context.event, `Skipping first comment`);
 }

--- a/src/handlers/comment/handlers/help.ts
+++ b/src/handlers/comment/handlers/help.ts
@@ -6,13 +6,13 @@ export async function listAvailableCommands(context: Context, body: string) {
   const runtime = Runtime.getState();
   const logger = runtime.logger;
   if (body != "/help") {
-    return logger.info("Skipping to list available commands.", { body });
+    return logger.info(context.event, "Skipping to list available commands.", { body });
   }
   const payload = context.event.payload as Payload;
   const issue = payload.issue;
 
   if (!issue) {
-    return logger.info("Skipping /help, reason: not issue");
+    return logger.info(context.event, "Skipping /help, reason: not issue");
   }
 
   return generateHelpMenu(context);

--- a/src/handlers/comment/handlers/help.ts
+++ b/src/handlers/comment/handlers/help.ts
@@ -1,18 +1,15 @@
 import { userCommands } from ".";
-import Runtime from "../../../bindings/bot-runtime";
-import { Context, Payload } from "../../../types";
+import { Context } from "../../../types";
 
 export async function listAvailableCommands(context: Context, body: string) {
-  const runtime = Runtime.getState();
-  const logger = runtime.logger;
+  const logger = context.logger;
   if (body != "/help") {
-    return logger.info(context.event, "Skipping to list available commands.", { body });
+    return logger.info("Skipping to list available commands.", { body });
   }
-  const payload = context.event.payload as Payload;
-  const issue = payload.issue;
+  const issue = context.payload.issue;
 
   if (!issue) {
-    return logger.info(context.event, "Skipping /help, reason: not issue");
+    return context.logger.info("Skipping /help, reason: not issue");
   }
 
   return generateHelpMenu(context);

--- a/src/handlers/comment/handlers/issue/allCommentScoring.ts
+++ b/src/handlers/comment/handlers/issue/allCommentScoring.ts
@@ -1,4 +1,3 @@
-import Runtime from "../../../../bindings/bot-runtime";
 import { Comment } from "../../../../types/payload";
 import { commentScoringByContributionClass } from "./comment-scoring-by-contribution-style";
 import { CommentScoring } from "./comment-scoring-rubric";
@@ -26,7 +25,7 @@ export async function allCommentScoring({
       const selection = usersByClass[contributionStyle as keyof typeof usersByClass];
 
       if (!selection) {
-        Runtime.getState().logger.verbose(context.event, `No ${String(contributionStyle)} found`);
+        context.logger.verbose(`No ${String(contributionStyle)} found`);
         return [];
       }
 

--- a/src/handlers/comment/handlers/issue/allCommentScoring.ts
+++ b/src/handlers/comment/handlers/issue/allCommentScoring.ts
@@ -26,7 +26,7 @@ export async function allCommentScoring({
       const selection = usersByClass[contributionStyle as keyof typeof usersByClass];
 
       if (!selection) {
-        Runtime.getState().logger.verbose(`No ${String(contributionStyle)} found`);
+        Runtime.getState().logger.verbose(context.event, `No ${String(contributionStyle)} found`);
         return [];
       }
 
@@ -38,6 +38,7 @@ export async function allCommentScoring({
           return [];
         }
         perUserCommentScoring(
+          context,
           user,
           commentsOfRole.filter((comment) => comment.user.id === user.id),
           scoring

--- a/src/handlers/comment/handlers/issue/assignee-scoring.ts
+++ b/src/handlers/comment/handlers/issue/assignee-scoring.ts
@@ -3,19 +3,23 @@ import Runtime from "../../../../bindings/bot-runtime";
 import { Issue, User } from "../../../../types/payload";
 import { ContributorView } from "./contribution-style-types";
 import { UserScoreDetails } from "./issue-shared-types";
+import { Context } from "../../../../types";
 
-export async function assigneeScoring({
-  issue,
-  source,
-  view,
-}: {
-  issue: Issue;
-  source: User[];
-  view: ContributorView;
-}): Promise<UserScoreDetails[]> {
+export async function assigneeScoring(
+  context: Context,
+  {
+    issue,
+    source,
+    view,
+  }: {
+    issue: Issue;
+    source: User[];
+    view: ContributorView;
+  }
+): Promise<UserScoreDetails[]> {
   // get the price label
   const priceLabels = issue.labels.filter((label) => label.name.startsWith("Price: "));
-  if (!priceLabels) throw Runtime.getState().logger.warn("Price label is undefined");
+  if (!priceLabels) throw Runtime.getState().logger.warn(context.event, "Price label is undefined");
 
   // get the smallest price label
   const priceLabel = priceLabels
@@ -28,7 +32,7 @@ export async function assigneeScoring({
     ?.shift();
 
   if (!priceLabel) {
-    throw Runtime.getState().logger.warn("Price label is undefined");
+    throw Runtime.getState().logger.warn(context.event, "Price label is undefined");
   }
 
   // get the price

--- a/src/handlers/comment/handlers/issue/assignee-scoring.ts
+++ b/src/handlers/comment/handlers/issue/assignee-scoring.ts
@@ -1,5 +1,4 @@
 import Decimal from "decimal.js";
-import Runtime from "../../../../bindings/bot-runtime";
 import { Issue, User } from "../../../../types/payload";
 import { ContributorView } from "./contribution-style-types";
 import { UserScoreDetails } from "./issue-shared-types";
@@ -19,7 +18,7 @@ export async function assigneeScoring(
 ): Promise<UserScoreDetails[]> {
   // get the price label
   const priceLabels = issue.labels.filter((label) => label.name.startsWith("Price: "));
-  if (!priceLabels) throw Runtime.getState().logger.warn(context.event, "Price label is undefined");
+  if (!priceLabels) throw context.logger.warn("Price label is undefined");
 
   // get the smallest price label
   const priceLabel = priceLabels
@@ -32,7 +31,7 @@ export async function assigneeScoring(
     ?.shift();
 
   if (!priceLabel) {
-    throw Runtime.getState().logger.warn(context.event, "Price label is undefined");
+    throw context.logger.warn("Price label is undefined");
   }
 
   // get the price

--- a/src/handlers/comment/handlers/issue/comment-scoring-rubric.ts
+++ b/src/handlers/comment/handlers/issue/comment-scoring-rubric.ts
@@ -3,7 +3,6 @@ import { JSDOM } from "jsdom";
 import Decimal from "decimal.js";
 import _ from "lodash";
 import MarkdownIt from "markdown-it";
-import Runtime from "../../../../bindings/bot-runtime";
 import { Comment } from "../../../../types/payload";
 import { ContributorClassesKeys } from "./contribution-style-types";
 import { FormatScoreConfig, FormatScoreConfigParams } from "./element-score-config";
@@ -226,7 +225,7 @@ export class CommentScoring {
 
   private _initialize(context: Context, comment: Comment, userId: number) {
     if (!this.commentScores[userId]) {
-      Runtime.getState().logger.debug(context.event, "good thing we initialized, was unsure if necessary");
+      context.logger.debug("good thing we initialized, was unsure if necessary");
       const initialCommentScoreValue = {
         totalScoreTotal: ZERO,
         wordScoreTotal: ZERO,
@@ -236,7 +235,7 @@ export class CommentScoring {
       this.commentScores[userId] = { ...initialCommentScoreValue };
     }
     if (!this.commentScores[userId].details[comment.id]) {
-      Runtime.getState().logger.debug(context.event, "good thing we initialized, was unsure if necessary");
+      context.logger.debug("good thing we initialized, was unsure if necessary");
       this.commentScores[userId].details[comment.id] = {
         totalScoreComment: ZERO,
         relevanceScoreComment: ZERO,

--- a/src/handlers/comment/handlers/issue/comment-scoring-rubric.ts
+++ b/src/handlers/comment/handlers/issue/comment-scoring-rubric.ts
@@ -7,6 +7,7 @@ import Runtime from "../../../../bindings/bot-runtime";
 import { Comment } from "../../../../types/payload";
 import { ContributorClassesKeys } from "./contribution-style-types";
 import { FormatScoreConfig, FormatScoreConfigParams } from "./element-score-config";
+import { Context } from "../../../../types";
 
 export type Tags = keyof HTMLElementTagNameMap;
 
@@ -188,7 +189,7 @@ export class CommentScoring {
     return wordCount;
   }
 
-  public computeElementScore(comment: Comment, userId: number) {
+  public computeElementScore(context: Context, comment: Comment, userId: number) {
     const htmlString = this._getRenderedCommentBody(comment);
     const formatStatistics = _.mapValues(_.cloneDeep(this._formatConfig), () => ({
       count: 0,
@@ -215,7 +216,7 @@ export class CommentScoring {
       }
     }
 
-    this._initialize(comment, userId);
+    this._initialize(context, comment, userId);
     // Store the element score for the comment
     this.commentScores[userId].details[comment.id].formatScoreComment = totalElementScore;
     this.commentScores[userId].details[comment.id].formatScoreCommentDetails = formatStatistics;
@@ -223,9 +224,9 @@ export class CommentScoring {
     return htmlString;
   }
 
-  private _initialize(comment: Comment, userId: number) {
+  private _initialize(context: Context, comment: Comment, userId: number) {
     if (!this.commentScores[userId]) {
-      Runtime.getState().logger.debug("good thing we initialized, was unsure if necessary");
+      Runtime.getState().logger.debug(context.event, "good thing we initialized, was unsure if necessary");
       const initialCommentScoreValue = {
         totalScoreTotal: ZERO,
         wordScoreTotal: ZERO,
@@ -235,7 +236,7 @@ export class CommentScoring {
       this.commentScores[userId] = { ...initialCommentScoreValue };
     }
     if (!this.commentScores[userId].details[comment.id]) {
-      Runtime.getState().logger.debug("good thing we initialized, was unsure if necessary");
+      Runtime.getState().logger.debug(context.event, "good thing we initialized, was unsure if necessary");
       this.commentScores[userId].details[comment.id] = {
         totalScoreComment: ZERO,
         relevanceScoreComment: ZERO,
@@ -248,11 +249,11 @@ export class CommentScoring {
     }
   }
 
-  public computeWordScore(comment: Comment, userId: number) {
+  public computeWordScore(context: Context, comment: Comment, userId: number) {
     const words = this._getWordsNotInDisabledElements(comment);
     const wordScoreDetails = this._calculateWordScores(words);
 
-    this._initialize(comment, userId);
+    this._initialize(context, comment, userId);
     this.commentScores[userId].details[comment.id].comment = comment;
     this.commentScores[userId].details[comment.id].wordScoreComment = this._calculateWordScoresTotals(wordScoreDetails);
     this.commentScores[userId].details[comment.id].wordScoreCommentDetails = wordScoreDetails;

--- a/src/handlers/comment/handlers/issue/generate-permit-2-signature.ts
+++ b/src/handlers/comment/handlers/issue/generate-permit-2-signature.ts
@@ -16,26 +16,26 @@ export async function generatePermit2Signature(
     payments: { evmNetworkId },
     keys: { evmPrivateEncrypted },
   } = context.config;
-  if (!evmPrivateEncrypted) throw runtime.logger.warn("No bot wallet private key defined");
+  if (!evmPrivateEncrypted) throw runtime.logger.warn(context.event, "No bot wallet private key defined");
   const { rpc, paymentToken } = getPayoutConfigByNetworkId(evmNetworkId);
   const { privateKey } = await decryptKeys(evmPrivateEncrypted);
 
-  if (!rpc) throw runtime.logger.error("RPC is not defined");
-  if (!privateKey) throw runtime.logger.error("Private key is not defined");
-  if (!paymentToken) throw runtime.logger.error("Payment token is not defined");
+  if (!rpc) throw runtime.logger.error(context.event, "RPC is not defined");
+  if (!privateKey) throw runtime.logger.error(context.event, "Private key is not defined");
+  if (!paymentToken) throw runtime.logger.error(context.event, "Payment token is not defined");
 
   let provider;
   let adminWallet;
   try {
     provider = new ethers.providers.JsonRpcProvider(rpc);
   } catch (error) {
-    throw runtime.logger.debug("Failed to instantiate provider", error);
+    throw runtime.logger.debug(context.event, "Failed to instantiate provider", error);
   }
 
   try {
     adminWallet = new ethers.Wallet(privateKey, provider);
   } catch (error) {
-    throw runtime.logger.debug("Failed to instantiate wallet", error);
+    throw runtime.logger.debug(context.event, "Failed to instantiate wallet", error);
   }
 
   const permitTransferFromData: PermitTransferFrom = {
@@ -55,7 +55,7 @@ export async function generatePermit2Signature(
   );
 
   const signature = await adminWallet._signTypedData(domain, types, values).catch((error) => {
-    throw runtime.logger.debug("Failed to sign typed data", error);
+    throw runtime.logger.debug(context.event, "Failed to sign typed data", error);
   });
 
   const transactionData: TransactionData = {
@@ -89,7 +89,7 @@ export async function generatePermit2Signature(
   url.searchParams.append("claim", base64encodedTxData);
   url.searchParams.append("network", evmNetworkId.toString());
 
-  runtime.logger.info("Generated permit2 signature", { transactionData, url: url.toString() });
+  runtime.logger.info(context.event, "Generated permit2 signature", { transactionData, url: url.toString() });
 
   return { transactionData, url };
 }

--- a/src/handlers/comment/handlers/issue/generate-permits.ts
+++ b/src/handlers/comment/handlers/issue/generate-permits.ts
@@ -41,7 +41,7 @@ async function generateComment(context: Context, totals: TotalsById) {
     const contributorName = userTotals.user.login;
     // const contributionClassName = userTotals.details[0].contribution as ContributorClassNames;
 
-    if (!evmPrivateEncrypted) throw runtime.logger.warn(context.event, "No bot wallet private key defined");
+    if (!evmPrivateEncrypted) throw context.logger.warn("No bot wallet private key defined");
 
     const beneficiaryAddress = await runtime.adapters.supabase.wallet.getAddress(parseInt(userId));
 

--- a/src/handlers/comment/handlers/issue/generate-permits.ts
+++ b/src/handlers/comment/handlers/issue/generate-permits.ts
@@ -41,7 +41,7 @@ async function generateComment(context: Context, totals: TotalsById) {
     const contributorName = userTotals.user.login;
     // const contributionClassName = userTotals.details[0].contribution as ContributorClassNames;
 
-    if (!evmPrivateEncrypted) throw runtime.logger.warn("No bot wallet private key defined");
+    if (!evmPrivateEncrypted) throw runtime.logger.warn(context.event, "No bot wallet private key defined");
 
     const beneficiaryAddress = await runtime.adapters.supabase.wallet.getAddress(parseInt(userId));
 

--- a/src/handlers/comment/handlers/issue/get-collaborator-ids-for-repo.ts
+++ b/src/handlers/comment/handlers/issue/get-collaborator-ids-for-repo.ts
@@ -1,8 +1,6 @@
-import Runtime from "../../../../bindings/bot-runtime";
 import { Context, Payload, User } from "../../../../types";
 
 export async function getCollaboratorsForRepo(context: Context): Promise<User[]> {
-  const runtime = Runtime.getState();
   const payload = context.event.payload as Payload;
   const collaboratorUsers: User[] = [];
 
@@ -26,7 +24,7 @@ export async function getCollaboratorsForRepo(context: Context): Promise<User[]>
       }
     }
   } catch (e: unknown) {
-    runtime.logger.error(context.event, "Fetching collaborator IDs for repo failed!", e);
+    context.logger.error("Fetching collaborator IDs for repo failed!", e);
   }
 
   return collaboratorUsers;

--- a/src/handlers/comment/handlers/issue/get-collaborator-ids-for-repo.ts
+++ b/src/handlers/comment/handlers/issue/get-collaborator-ids-for-repo.ts
@@ -26,7 +26,7 @@ export async function getCollaboratorsForRepo(context: Context): Promise<User[]>
       }
     }
   } catch (e: unknown) {
-    runtime.logger.error("Fetching collaborator IDs for repo failed!", e);
+    runtime.logger.error(context.event, "Fetching collaborator IDs for repo failed!", e);
   }
 
   return collaboratorUsers;

--- a/src/handlers/comment/handlers/issue/getPullRequestComments.ts
+++ b/src/handlers/comment/handlers/issue/getPullRequestComments.ts
@@ -5,7 +5,7 @@ import { Comment } from "../../../../types/payload";
 
 export async function getPullRequestComments(context: Context, owner: string, repository: string, issueNumber: number) {
   const pullRequestComments: Comment[] = [];
-  const linkedPullRequests = await getLinkedPullRequests({ owner, repository, issue: issueNumber });
+  const linkedPullRequests = await getLinkedPullRequests(context, { owner, repository, issue: issueNumber });
   if (linkedPullRequests.length) {
     const linkedCommentsPromises = linkedPullRequests.map((pull) => getAllIssueComments(context, pull.number));
     const linkedCommentsResolved = await Promise.all(linkedCommentsPromises);

--- a/src/handlers/comment/handlers/issue/issue-closed.ts
+++ b/src/handlers/comment/handlers/issue/issue-closed.ts
@@ -1,7 +1,6 @@
-import { Logs } from "../../../../adapters/supabase";
 import Runtime from "../../../../bindings/bot-runtime";
 import { checkUserPermissionForRepoAndOrg, getAllIssueComments } from "../../../../helpers";
-import { BotConfig, Context } from "../../../../types";
+import { Context } from "../../../../types";
 import { Comment, Issue, Payload, StateReason } from "../../../../types/payload";
 import structuredMetadata from "../../../shared/structured-metadata";
 import { generatePermits } from "./generate-permits";
@@ -16,14 +15,11 @@ const botCommentsFilter = (comment: Comment) => comment.user.type === "Bot"; /* 
 export async function issueClosed(context: Context) {
   // TODO: delegate permit calculation to GitHub Action
 
-  const runtime = Runtime.getState();
-  const logger = runtime.logger;
   const payload = context.event.payload as Payload;
   const issue = payload.issue as Issue;
-  const config = context.config;
 
   const { issueComments, owner, repository, issueNumber } = await getEssentials(context);
-  await preflightChecks({ issue, logger, issueComments, config, payload, context });
+  await preflightChecks({ issue, issueComments, context });
 
   // === Calculate Permit === //
 
@@ -49,10 +45,10 @@ async function getEssentials(context: Context) {
   const issue = payload.issue as Issue;
   const runtime = Runtime.getState();
   const logger = runtime.logger;
-  if (!issue) throw runtime.logger.error(context.event, "Issue is not defined");
+  if (!issue) throw context.logger.error("Issue is not defined");
   const issueComments = await getAllIssueComments(context, issue.number);
   const owner = payload?.organization?.login || payload.repository.owner.login;
-  if (!owner) throw logger.error(context.event, "Owner is not defined");
+  if (!owner) throw context.logger.error("Owner is not defined");
   const repository = payload?.repository?.name;
   const issueNumber = issue.number;
   return { issue, runtime, logger, issueComments, owner, repository, issueNumber };
@@ -61,37 +57,35 @@ async function getEssentials(context: Context) {
 
 interface PreflightChecksParams {
   issue: Issue;
-  logger: Logs;
   issueComments: Comment[];
-  config: BotConfig;
-  payload: Payload;
   context: Context;
 }
-async function preflightChecks({ issue, logger, issueComments, config, payload, context }: PreflightChecksParams) {
-  if (!issue) throw logger.error(context.event, "Permit generation skipped because issue is undefined");
+
+async function preflightChecks({ issue, issueComments, context }: PreflightChecksParams) {
+  const { payload, config } = context;
+  if (!issue) throw context.logger.error("Permit generation skipped because issue is undefined");
   if (issue.state_reason !== StateReason.COMPLETED)
-    throw logger.info(context.event, "Issue was not closed as completed. Skipping.", { issue });
+    throw context.logger.info("Issue was not closed as completed. Skipping.", { issue });
   if (config.features.publicAccessControl.fundExternalClosedIssue) {
     const userHasPermission = await checkUserPermissionForRepoAndOrg(context, payload.sender.login);
     if (!userHasPermission)
-      throw logger.warn(
-        context.event,
+      throw context.logger.warn(
         "Permit generation disabled because this issue has been closed by an external contributor."
       );
   }
 
   const priceLabels = issue.labels.find((label) => label.name.startsWith("Price: "));
   if (!priceLabels) {
-    throw logger.warn(context.event, "No price label has been set. Skipping permit generation.", {
+    throw context.logger.warn("No price label has been set. Skipping permit generation.", {
       labels: issue.labels,
     });
   }
 
   const botComments = issueComments.filter(botCommentsFilter);
-  checkIfPermitsAlreadyPosted(context, botComments, logger);
+  checkIfPermitsAlreadyPosted(context, botComments);
 }
 
-function checkIfPermitsAlreadyPosted(context: Context, botComments: Comment[], logger: Logs) {
+function checkIfPermitsAlreadyPosted(context: Context, botComments: Comment[]) {
   botComments.forEach((comment) => {
     const parsed = structuredMetadata.parse(comment.body);
     if (parsed) {
@@ -99,7 +93,7 @@ function checkIfPermitsAlreadyPosted(context: Context, botComments: Comment[], l
       if (parsed.caller === "generatePermits") {
         // in the comment metadata we store what function rendered the comment
         console.trace({ parsed });
-        throw logger.warn(context.event, "Permit already posted");
+        throw context.logger.warn("Permit already posted");
       }
     }
   });

--- a/src/handlers/comment/handlers/issue/perUserCommentScoring.ts
+++ b/src/handlers/comment/handlers/issue/perUserCommentScoring.ts
@@ -1,10 +1,16 @@
+import { Context } from "../../../../types";
 import { Comment, User } from "../../../../types/payload";
 import { CommentScoring } from "./comment-scoring-rubric";
 
-export function perUserCommentScoring(user: User, comments: Comment[], scoringRubric: CommentScoring): CommentScoring {
+export function perUserCommentScoring(
+  context: Context,
+  user: User,
+  comments: Comment[],
+  scoringRubric: CommentScoring
+): CommentScoring {
   for (const comment of comments) {
-    scoringRubric.computeWordScore(comment, user.id);
-    scoringRubric.computeElementScore(comment, user.id);
+    scoringRubric.computeWordScore(context, comment, user.id);
+    scoringRubric.computeElementScore(context, comment, user.id);
   }
   scoringRubric.compileTotalUserScores();
   return scoringRubric;

--- a/src/handlers/comment/handlers/issue/relevance-scoring.ts
+++ b/src/handlers/comment/handlers/issue/relevance-scoring.ts
@@ -102,7 +102,7 @@ async function sampleRelevanceScores(
       issue,
       maxConcurrency: BATCH_SIZE,
     });
-    const filteredSamples = filterSamples(fetchedSamples, correctLength);
+    const filteredSamples = filterSamples(context, fetchedSamples, correctLength);
     const averagedSample = averageSamples(filteredSamples, 10);
     batchSamples.push(averagedSample);
   }
@@ -132,10 +132,10 @@ interface InEachRequestParams {
   maxConcurrency: number;
 }
 
-function filterSamples(batchResults: number[][], correctLength: number) {
+function filterSamples(context: Context, batchResults: number[][], correctLength: number) {
   return batchResults.filter((result) => {
     if (result.length != correctLength) {
-      Runtime.getState().logger.error("Correct length is not defined", {
+      Runtime.getState().logger.error(context.event, "Correct length is not defined", {
         batchResultsLength: batchResults.length,
         result,
       });

--- a/src/handlers/comment/handlers/issue/relevance-scoring.ts
+++ b/src/handlers/comment/handlers/issue/relevance-scoring.ts
@@ -1,7 +1,6 @@
 import Decimal from "decimal.js";
 import { encodingForModel } from "js-tiktoken";
 import OpenAI from "openai";
-import Runtime from "../../../../bindings/bot-runtime";
 import { Context } from "../../../../types";
 import { Comment, Issue } from "../../../../types/payload";
 
@@ -135,7 +134,7 @@ interface InEachRequestParams {
 function filterSamples(context: Context, batchResults: number[][], correctLength: number) {
   return batchResults.filter((result) => {
     if (result.length != correctLength) {
-      Runtime.getState().logger.error(context.event, "Correct length is not defined", {
+      context.logger.error("Correct length is not defined", {
         batchResultsLength: batchResults.length,
         result,
       });

--- a/src/handlers/comment/handlers/issue/scoreSources.ts
+++ b/src/handlers/comment/handlers/issue/scoreSources.ts
@@ -17,7 +17,7 @@ export async function aggregateAndScoreContributions({
 }: ScoreParams): Promise<UserScoreDetails[]> {
   const issueIssuerSpecification = await issuerSpecificationScoring({ context, issue, view: "Issue" });
 
-  const issueAssigneeTask = await assigneeTaskScoring({
+  const issueAssigneeTask = await assigneeTaskScoring(context, {
     issue,
     source: issue.assignees.filter((assignee): assignee is User => Boolean(assignee)),
     view: "Issue",

--- a/src/handlers/comment/handlers/labels.ts
+++ b/src/handlers/comment/handlers/labels.ts
@@ -3,19 +3,15 @@ import { isUserAdminOrBillingManager } from "../../../helpers";
 import { Context, Payload } from "../../../types";
 
 export async function setLabels(context: Context, body: string) {
-  const runtime = Runtime.getState();
-  const logger = runtime.logger;
+  const logger = context.logger;
   const payload = context.event.payload as Payload;
   const sender = payload.sender.login;
 
   const sufficientPrivileges = await isUserAdminOrBillingManager(context, sender);
   if (!sufficientPrivileges)
-    return logger.info(
-      context.event,
-      `You are not an admin and do not have the required permissions to access this function.`
-    ); // if sender is not admin, return
+    return logger.info(`You are not an admin and do not have the required permissions to access this function.`); // if sender is not admin, return
 
-  if (!payload.issue) return logger.info(context.event, `Skipping '/labels' because of no issue instance`);
+  if (!payload.issue) return context.logger.info(`Skipping '/labels' because of no issue instance`);
 
   if (body.startsWith("/labels")) {
     const { username, labels } = parseComment(body);
@@ -32,12 +28,11 @@ export async function setLabels(context: Context, body: string) {
     const userId = await user.getUserId(context.event, username);
     await access.setAccess(labels, nodeInfo, userId);
     if (!labels.length) {
-      return logger.ok(context.event, "Successfully cleared access", { username });
+      return context.logger.ok("Successfully cleared access", { username });
     }
-    return logger.ok(context.event, "Successfully set access", { username, labels });
+    return context.logger.ok("Successfully set access", { username, labels });
   } else {
     throw logger.error(
-      context.event,
       `Invalid syntax for allow \n usage: '/labels set-(access type) @user true|false' \n  ex-1 /labels set-multiplier @user false`
     );
   }

--- a/src/handlers/comment/handlers/labels.ts
+++ b/src/handlers/comment/handlers/labels.ts
@@ -10,9 +10,12 @@ export async function setLabels(context: Context, body: string) {
 
   const sufficientPrivileges = await isUserAdminOrBillingManager(context, sender);
   if (!sufficientPrivileges)
-    return logger.info(`You are not an admin and do not have the required permissions to access this function.`); // if sender is not admin, return
+    return logger.info(
+      context.event,
+      `You are not an admin and do not have the required permissions to access this function.`
+    ); // if sender is not admin, return
 
-  if (!payload.issue) return logger.info(`Skipping '/labels' because of no issue instance`);
+  if (!payload.issue) return logger.info(context.event, `Skipping '/labels' because of no issue instance`);
 
   if (body.startsWith("/labels")) {
     const { username, labels } = parseComment(body);
@@ -26,14 +29,15 @@ export async function setLabels(context: Context, body: string) {
       node_url: url,
     };
 
-    const userId = await user.getUserId(username);
+    const userId = await user.getUserId(context.event, username);
     await access.setAccess(labels, nodeInfo, userId);
     if (!labels.length) {
-      return logger.ok("Successfully cleared access", { username });
+      return logger.ok(context.event, "Successfully cleared access", { username });
     }
-    return logger.ok("Successfully set access", { username, labels });
+    return logger.ok(context.event, "Successfully set access", { username, labels });
   } else {
     throw logger.error(
+      context.event,
       `Invalid syntax for allow \n usage: '/labels set-(access type) @user true|false' \n  ex-1 /labels set-multiplier @user false`
     );
   }

--- a/src/handlers/comment/handlers/multiplier.ts
+++ b/src/handlers/comment/handlers/multiplier.ts
@@ -13,16 +13,15 @@ import { Context, Payload } from "../../../types";
  * /multiplier @user "Multiplier reason" 0.5
  **/
 export async function multiplier(context: Context, body: string) {
-  const runtime = Runtime.getState();
-  const logger = runtime.logger;
+  const logger = context.logger;
   const payload = context.event.payload as Payload;
   const sender = payload.sender.login;
   const repo = payload.repository;
   const comment = payload.comment;
-  if (!comment) return logger.info(context.event, `Skipping '/multiplier' because of no comment instance`);
+  if (!comment) return context.logger.info(`Skipping '/multiplier' because of no comment instance`);
   const issue = payload.issue;
-  logger.info(context.event, "Running '/multiplier' command handler", { sender });
-  if (!issue) return logger.info(context.event, `Skipping '/multiplier' because of no issue instance`);
+  context.logger.info("Running '/multiplier' command handler", { sender });
+  if (!issue) return context.logger.info(`Skipping '/multiplier' because of no issue instance`);
   const regex = /(".*?"|[^"\s]+)(?=\s*|\s*$)/g;
   const matches = body.match(regex);
   matches?.shift();
@@ -48,7 +47,7 @@ export async function multiplier(context: Context, body: string) {
 
     // if sender is not admin or billing_manager, check db for access
     if (sufficientPrivileges) {
-      logger.info(context.event, "Getting multiplier access", {
+      context.logger.info("Getting multiplier access", {
         repo: repo.full_name,
         user: sender,
       });
@@ -62,7 +61,6 @@ export async function multiplier(context: Context, body: string) {
 
       if (!accessible) {
         return logger.warn(
-          context.event,
           "Insufficient permissions to update the payout multiplier. User is not an 'admin' or 'billing_manager'",
           {
             repo: repo.full_name,
@@ -71,14 +69,13 @@ export async function multiplier(context: Context, body: string) {
         );
       }
     }
-    logger.info(context.event, "Upserting to the wallet table", { username, taskMultiplier, reason });
+    context.logger.info("Upserting to the wallet table", { username, taskMultiplier, reason });
 
     const { access } = Runtime.getState().adapters.supabase;
     await access.upsertMultiplier(payload.sender.id, taskMultiplier, reason, comment);
 
     if (taskMultiplier > 1) {
       return logger.ok(
-        context.event,
         "Successfully changed the payout multiplier. \
         This feature is designed to limit the contributor's compensation \
         for any task on the current repository \
@@ -91,7 +88,7 @@ export async function multiplier(context: Context, body: string) {
         }
       );
     } else {
-      return logger.ok(context.event, "Successfully changed the payout multiplier", {
+      return context.logger.ok("Successfully changed the payout multiplier", {
         username,
         taskMultiplier,
         reason,
@@ -99,7 +96,6 @@ export async function multiplier(context: Context, body: string) {
     }
   } else {
     return logger.error(
-      context.event,
       "Invalid body for taskMultiplier command. Example usage: /multiplier @user 0.5 'Multiplier reason'"
     );
   }

--- a/src/handlers/comment/handlers/payout.ts
+++ b/src/handlers/comment/handlers/payout.ts
@@ -7,7 +7,7 @@ export async function autoPay(context: Context, body: string) {
   const payload = context.event.payload as Payload;
   const logger = runtime.logger;
 
-  logger.info("Running '/autopay' command handler", { sender: payload.sender.login });
+  logger.info(context.event, "Running '/autopay' command handler", { sender: payload.sender.login });
 
   const pattern = /^\/autopay (true|false)$/;
   const autopayCommand = body.match(pattern);
@@ -16,12 +16,14 @@ export async function autoPay(context: Context, body: string) {
     const hasSufficientPrivileges = await isUserAdminOrBillingManager(context, payload.sender.login);
     if (!hasSufficientPrivileges) {
       return logger.warn(
+        context.event,
         "You must be an 'admin' or 'billing_manager' to toggle automatic payments for completed issues."
       );
     }
-    return logger.ok("Automatic payment for this issue state:", { autopayCommand });
+    return logger.ok(context.event, "Automatic payment for this issue state:", { autopayCommand });
   }
   return logger.warn(
+    context.event,
     `Invalid command. Please use the following format: \`/autopay true\` or \`/autopay false\` to toggle automatic payments for completed issues.`
   );
 }

--- a/src/handlers/comment/handlers/payout.ts
+++ b/src/handlers/comment/handlers/payout.ts
@@ -1,13 +1,11 @@
-import Runtime from "../../../bindings/bot-runtime";
 import { Context, Payload } from "../../../types";
 import { isUserAdminOrBillingManager } from "../../../helpers/issue";
 
 export async function autoPay(context: Context, body: string) {
-  const runtime = Runtime.getState();
   const payload = context.event.payload as Payload;
-  const logger = runtime.logger;
+  const logger = context.logger;
 
-  logger.info(context.event, "Running '/autopay' command handler", { sender: payload.sender.login });
+  logger.info("Running '/autopay' command handler", { sender: payload.sender.login });
 
   const pattern = /^\/autopay (true|false)$/;
   const autopayCommand = body.match(pattern);
@@ -16,14 +14,12 @@ export async function autoPay(context: Context, body: string) {
     const hasSufficientPrivileges = await isUserAdminOrBillingManager(context, payload.sender.login);
     if (!hasSufficientPrivileges) {
       return logger.warn(
-        context.event,
         "You must be an 'admin' or 'billing_manager' to toggle automatic payments for completed issues."
       );
     }
-    return logger.ok(context.event, "Automatic payment for this issue state:", { autopayCommand });
+    return context.logger.ok("Automatic payment for this issue state:", { autopayCommand });
   }
   return logger.warn(
-    context.event,
     `Invalid command. Please use the following format: \`/autopay true\` or \`/autopay false\` to toggle automatic payments for completed issues.`
   );
 }

--- a/src/handlers/comment/handlers/query.ts
+++ b/src/handlers/comment/handlers/query.ts
@@ -8,24 +8,24 @@ export async function query(context: Context, body: string) {
     payload = context.event.payload as Payload,
     sender = payload.sender.login;
 
-  logger.info("Running '/query' command handler", { sender });
+  logger.info(context.event, "Running '/query' command handler", { sender });
 
   const issue = payload.issue;
-  if (!issue) return logger.info(`Skipping '/query' because of no issue instance`);
+  if (!issue) return logger.info(context.event, `Skipping '/query' because of no issue instance`);
 
   const regex = /^\/query\s+@([\w-]+)\s*$/;
   const matches = body.match(regex);
   const username = matches?.[1];
 
   if (!username) {
-    throw logger.error("Invalid body for query command \n usage /query @user");
+    throw logger.error(context.event, "Invalid body for query command \n usage /query @user");
   }
 
   const database = runtime.adapters.supabase;
   const usernameResponse = await context.event.octokit.users.getByUsername({ username });
   const user = usernameResponse.data;
   if (!user) {
-    throw logger.error("User not found", { username });
+    throw logger.error(context.event, "User not found", { username });
   }
   const accessData = await database.access.getAccess(user.id);
   const walletAddress = await database.wallet.getAddress(user.id);
@@ -34,7 +34,7 @@ export async function query(context: Context, body: string) {
   messageBuffer.push(renderMarkdownTableHeader());
 
   if (!accessData && !walletAddress) {
-    return logger.warn("No access or wallet found for user", { username });
+    return logger.warn(context.event, "No access or wallet found for user", { username });
   }
   if (accessData) {
     messageBuffer.push(appendToMarkdownTableBody(accessData));

--- a/src/handlers/comment/handlers/query.ts
+++ b/src/handlers/comment/handlers/query.ts
@@ -4,28 +4,28 @@ import _ from "lodash";
 
 export async function query(context: Context, body: string) {
   const runtime = Runtime.getState(),
-    logger = runtime.logger,
+    logger = context.logger,
     payload = context.event.payload as Payload,
     sender = payload.sender.login;
 
-  logger.info(context.event, "Running '/query' command handler", { sender });
+  logger.info("Running '/query' command handler", { sender });
 
   const issue = payload.issue;
-  if (!issue) return logger.info(context.event, `Skipping '/query' because of no issue instance`);
+  if (!issue) return logger.info(`Skipping '/query' because of no issue instance`);
 
   const regex = /^\/query\s+@([\w-]+)\s*$/;
   const matches = body.match(regex);
   const username = matches?.[1];
 
   if (!username) {
-    throw logger.error(context.event, "Invalid body for query command \n usage /query @user");
+    throw logger.error("Invalid body for query command \n usage /query @user");
   }
 
   const database = runtime.adapters.supabase;
   const usernameResponse = await context.event.octokit.users.getByUsername({ username });
   const user = usernameResponse.data;
   if (!user) {
-    throw logger.error(context.event, "User not found", { username });
+    throw logger.error("User not found", { username });
   }
   const accessData = await database.access.getAccess(user.id);
   const walletAddress = await database.wallet.getAddress(user.id);
@@ -34,7 +34,7 @@ export async function query(context: Context, body: string) {
   messageBuffer.push(renderMarkdownTableHeader());
 
   if (!accessData && !walletAddress) {
-    return logger.warn(context.event, "No access or wallet found for user", { username });
+    return logger.warn("No access or wallet found for user", { username });
   }
   if (accessData) {
     messageBuffer.push(appendToMarkdownTableBody(accessData));

--- a/src/handlers/comment/handlers/unassign.ts
+++ b/src/handlers/comment/handlers/unassign.ts
@@ -6,24 +6,24 @@ export async function unassign(context: Context, body: string) {
   const runtime = Runtime.getState();
   const logger = runtime.logger;
   if (!body.startsWith("/stop")) {
-    return logger.error("Skipping to unassign", { body });
+    return logger.error(context.event, "Skipping to unassign", { body });
   }
 
   const payload = context.event.payload as Payload;
-  logger.info("Running '/stop' command handler", { sender: payload.sender.login });
+  logger.info(context.event, "Running '/stop' command handler", { sender: payload.sender.login });
   const issue = payload.issue;
   if (!issue) {
-    return logger.info(`Skipping '/stop' because of no issue instance`);
+    return logger.info(context.event, `Skipping '/stop' because of no issue instance`);
   }
 
   const issueNumber = issue.number;
   const assignees = payload.issue?.assignees ?? [];
 
   if (assignees.length == 0) {
-    return logger.warn("No assignees found for issue", { issueNumber });
+    return logger.warn(context.event, "No assignees found for issue", { issueNumber });
   }
   const shouldUnassign = assignees[0]?.login.toLowerCase() == payload.sender.login.toLowerCase();
-  logger.debug("Unassigning sender", {
+  logger.debug(context.event, "Unassigning sender", {
     sender: payload.sender.login.toLowerCase(),
     assignee: assignees[0]?.login.toLowerCase(),
     shouldUnassign,
@@ -39,7 +39,10 @@ export async function unassign(context: Context, body: string) {
       issue_number: issueNumber,
       assignees: [payload.sender.login],
     });
-    return logger.ok("You have been unassigned from the task", { issueNumber, user: payload.sender.login });
+    return logger.ok(context.event, "You have been unassigned from the task", {
+      issueNumber,
+      user: payload.sender.login,
+    });
   }
-  return logger.warn("You are not assigned to this task", { issueNumber, user: payload.sender.login });
+  return logger.warn(context.event, "You are not assigned to this task", { issueNumber, user: payload.sender.login });
 }

--- a/src/handlers/comment/handlers/unassign.ts
+++ b/src/handlers/comment/handlers/unassign.ts
@@ -1,29 +1,27 @@
-import Runtime from "../../../bindings/bot-runtime";
 import { Context, Payload } from "../../../types";
 import { closePullRequestForAnIssue } from "../../assign/index";
 
 export async function unassign(context: Context, body: string) {
-  const runtime = Runtime.getState();
-  const logger = runtime.logger;
+  const logger = context.logger;
   if (!body.startsWith("/stop")) {
-    return logger.error(context.event, "Skipping to unassign", { body });
+    return logger.error("Skipping to unassign", { body });
   }
 
   const payload = context.event.payload as Payload;
-  logger.info(context.event, "Running '/stop' command handler", { sender: payload.sender.login });
+  logger.info("Running '/stop' command handler", { sender: payload.sender.login });
   const issue = payload.issue;
   if (!issue) {
-    return logger.info(context.event, `Skipping '/stop' because of no issue instance`);
+    return logger.info(`Skipping '/stop' because of no issue instance`);
   }
 
   const issueNumber = issue.number;
   const assignees = payload.issue?.assignees ?? [];
 
   if (assignees.length == 0) {
-    return logger.warn(context.event, "No assignees found for issue", { issueNumber });
+    return logger.warn("No assignees found for issue", { issueNumber });
   }
   const shouldUnassign = assignees[0]?.login.toLowerCase() == payload.sender.login.toLowerCase();
-  logger.debug(context.event, "Unassigning sender", {
+  logger.debug("Unassigning sender", {
     sender: payload.sender.login.toLowerCase(),
     assignee: assignees[0]?.login.toLowerCase(),
     shouldUnassign,
@@ -39,10 +37,10 @@ export async function unassign(context: Context, body: string) {
       issue_number: issueNumber,
       assignees: [payload.sender.login],
     });
-    return logger.ok(context.event, "You have been unassigned from the task", {
+    return logger.ok("You have been unassigned from the task", {
       issueNumber,
       user: payload.sender.login,
     });
   }
-  return logger.warn(context.event, "You are not assigned to this task", { issueNumber, user: payload.sender.login });
+  return logger.warn("You are not assigned to this task", { issueNumber, user: payload.sender.login });
 }

--- a/src/handlers/comment/handlers/wallet.ts
+++ b/src/handlers/comment/handlers/wallet.ts
@@ -1,5 +1,4 @@
 import { constants, ethers } from "ethers";
-import { Logs } from "../../../adapters/supabase";
 import Runtime from "../../../bindings/bot-runtime";
 import { resolveAddress } from "../../../helpers";
 import { Context, Payload } from "../../../types";
@@ -21,7 +20,7 @@ export async function registerWallet(context: Context, body: string) {
   const runtime = Runtime.getState();
   const payload = context.event.payload as Payload;
   const config = context.config;
-  const logger = runtime.logger;
+  const logger = context.logger;
   const sender = payload.sender.login;
 
   const regexForAddress = /(0x[a-fA-F0-9]{40})/g;
@@ -30,25 +29,24 @@ export async function registerWallet(context: Context, body: string) {
   const ensName = extractEnsName(body.replace("/wallet", "").trim());
 
   if (!address && ensName) {
-    logger.info(context.event, "Trying to resolve address from ENS name", { ensName });
+    context.logger.info("Trying to resolve address from ENS name", { ensName });
     address = await resolveAddress(ensName);
     if (!address) {
-      throw logger.error(context.event, "Resolving address from ENS name failed", { ensName });
+      throw context.logger.error("Resolving address from ENS name failed", { ensName });
     }
-    logger.ok(context.event, "Resolved address from ENS name", { ensName, address });
+    context.logger.ok("Resolved address from ENS name", { ensName, address });
   }
 
   if (!address) {
-    return logger.info(context.event, "Skipping to register a wallet address because both address/ens doesn't exist");
+    return context.logger.info("Skipping to register a wallet address because both address/ens doesn't exist");
   }
 
   if (config.miscellaneous.registerWalletWithVerification) {
-    _registerWalletWithVerification(context, body, address, logger);
+    _registerWalletWithVerification(context, body, address);
   }
 
   if (address == constants.AddressZero) {
     return logger.warn(
-      context.event,
       "Skipping to register a wallet address because user is trying to set their address to null address"
     );
   }
@@ -56,13 +54,13 @@ export async function registerWallet(context: Context, body: string) {
   if (payload.comment) {
     const { wallet } = runtime.adapters.supabase;
     await wallet.upsertWalletAddress(context.event, address);
-    return logger.ok(context.event, "Successfully registered wallet address", { sender, address });
+    return context.logger.ok("Successfully registered wallet address", { sender, address });
   } else {
     throw new Error("Payload comment is undefined");
   }
 }
 
-function _registerWalletWithVerification(context: Context, body: string, address: string, logger: Logs) {
+function _registerWalletWithVerification(context: Context, body: string, address: string) {
   const regexForSigHash = /(0x[a-fA-F0-9]{130})/g;
   const sigHashMatches = body.match(regexForSigHash);
   const sigHash = sigHashMatches ? sigHashMatches[0] : null;
@@ -73,10 +71,10 @@ function _registerWalletWithVerification(context: Context, body: string, address
     const isSigHashValid =
       sigHash && ethers.utils.verifyMessage(messageToSign, sigHash) == ethers.utils.getAddress(address);
     if (!isSigHashValid) {
-      throw logger.error(context.event, failedSigLogMsg);
+      throw context.logger.error(failedSigLogMsg);
     }
   } catch (e) {
-    logger.error(context.event, "Exception thrown by verifyMessage for /wallet: ", e);
-    throw logger.error(context.event, failedSigLogMsg);
+    context.logger.error("Exception thrown by verifyMessage for /wallet: ", e);
+    throw context.logger.error(failedSigLogMsg);
   }
 }

--- a/src/handlers/label/index.ts
+++ b/src/handlers/label/index.ts
@@ -3,21 +3,20 @@ import { hasLabelEditPermission } from "../../helpers";
 import { Context, Payload } from "../../types";
 
 export async function watchLabelChange(context: Context) {
-  const runtime = Runtime.getState();
-  const logger = runtime.logger;
+  const logger = context.logger;
 
   const payload = context.event.payload as Payload;
   const { label, changes, sender } = payload;
 
   const previousLabel = changes?.name?.from;
   if (!previousLabel) {
-    throw logger.error(context.event, "previous label name is undefined");
+    throw logger.error("previous label name is undefined");
   }
   const currentLabel = label?.name;
   const triggerUser = sender.login;
 
   if (!previousLabel || !currentLabel) {
-    return logger.debug(context.event, "No label name change.. skipping");
+    return logger.debug("No label name change.. skipping");
   }
 
   // check if user is authorized to make the change
@@ -31,5 +30,5 @@ export async function watchLabelChange(context: Context) {
     authorized: hasAccess,
     repository: payload.repository,
   });
-  return logger.debug(context.event, "label name change saved to db");
+  return logger.debug("label name change saved to db");
 }

--- a/src/handlers/label/index.ts
+++ b/src/handlers/label/index.ts
@@ -11,13 +11,13 @@ export async function watchLabelChange(context: Context) {
 
   const previousLabel = changes?.name?.from;
   if (!previousLabel) {
-    throw logger.error("previous label name is undefined");
+    throw logger.error(context.event, "previous label name is undefined");
   }
   const currentLabel = label?.name;
   const triggerUser = sender.login;
 
   if (!previousLabel || !currentLabel) {
-    return logger.debug("No label name change.. skipping");
+    return logger.debug(context.event, "No label name change.. skipping");
   }
 
   // check if user is authorized to make the change
@@ -31,5 +31,5 @@ export async function watchLabelChange(context: Context) {
     authorized: hasAccess,
     repository: payload.repository,
   });
-  return logger.debug("label name change saved to db");
+  return logger.debug(context.event, "label name change saved to db");
 }

--- a/src/handlers/pricing/action.ts
+++ b/src/handlers/pricing/action.ts
@@ -1,14 +1,12 @@
-import Runtime from "../../bindings/bot-runtime";
 import { calculateLabelValue, clearAllPriceLabelsOnIssue } from "../../helpers";
 import { Label, Context } from "../../types";
 
 export async function handleParentIssue(context: Context, labels: Label[]) {
-  const runtime = Runtime.getState();
   const issuePrices = labels.filter((label) => label.name.toString().startsWith("Price:"));
   if (issuePrices.length) {
     await clearAllPriceLabelsOnIssue(context);
   }
-  throw runtime.logger.warn(context.event, "Pricing is disabled on parent issues.");
+  throw context.logger.warn("Pricing is disabled on parent issues.");
 }
 
 export function sortLabelsByValue(labels: Label[]) {

--- a/src/handlers/pricing/action.ts
+++ b/src/handlers/pricing/action.ts
@@ -8,7 +8,7 @@ export async function handleParentIssue(context: Context, labels: Label[]) {
   if (issuePrices.length) {
     await clearAllPriceLabelsOnIssue(context);
   }
-  throw runtime.logger.warn("Pricing is disabled on parent issues.");
+  throw runtime.logger.warn(context.event, "Pricing is disabled on parent issues.");
 }
 
 export function sortLabelsByValue(labels: Label[]) {

--- a/src/handlers/pricing/pre.ts
+++ b/src/handlers/pricing/pre.ts
@@ -1,4 +1,3 @@
-import Runtime from "../../bindings/bot-runtime";
 import { calculateLabelValue, createLabel, listLabelsForRepo } from "../../helpers";
 import { Context } from "../../types";
 import { calculateTaskPrice } from "../shared/pricing";
@@ -7,16 +6,15 @@ import { calculateTaskPrice } from "../shared/pricing";
 // If there's something missing, they will be added
 
 export async function syncPriceLabelsToConfig(context: Context) {
-  const runtime = Runtime.getState();
   const config = context.config;
-  const logger = runtime.logger;
+  const logger = context.logger;
 
   const {
     features: { assistivePricing },
   } = config;
 
   if (!assistivePricing) {
-    logger.info(context.event, `Assistive pricing is disabled`);
+    logger.info(`Assistive pricing is disabled`);
     return;
   }
 
@@ -44,8 +42,8 @@ export async function syncPriceLabelsToConfig(context: Context) {
 
   // Create missing labels
   if (missingLabels.length > 0) {
-    logger.info(context.event, "Missing labels found, creating them", { missingLabels });
+    logger.info("Missing labels found, creating them", { missingLabels });
     await Promise.all(missingLabels.map((label) => createLabel(context, label)));
-    logger.info(context.event, `Creating missing labels done`);
+    logger.info(`Creating missing labels done`);
   }
 }

--- a/src/handlers/pricing/pre.ts
+++ b/src/handlers/pricing/pre.ts
@@ -16,7 +16,7 @@ export async function syncPriceLabelsToConfig(context: Context) {
   } = config;
 
   if (!assistivePricing) {
-    logger.info(`Assistive pricing is disabled`);
+    logger.info(context.event, `Assistive pricing is disabled`);
     return;
   }
 
@@ -44,8 +44,8 @@ export async function syncPriceLabelsToConfig(context: Context) {
 
   // Create missing labels
   if (missingLabels.length > 0) {
-    logger.info("Missing labels found, creating them", { missingLabels });
+    logger.info(context.event, "Missing labels found, creating them", { missingLabels });
     await Promise.all(missingLabels.map((label) => createLabel(context, label)));
-    logger.info(`Creating missing labels done`);
+    logger.info(context.event, `Creating missing labels done`);
   }
 }

--- a/src/handlers/processors.ts
+++ b/src/handlers/processors.ts
@@ -19,8 +19,6 @@ import Runtime from "../bindings/bot-runtime";
  * TODO: all MUST receive `Context` as the only parameter
  */
 
-const runtime = Runtime.getState();
-
 export const processors: Record<string, Handler> = {
   [GitHubEvent.ISSUES_OPENED]: {
     pre: [],
@@ -29,7 +27,7 @@ export const processors: Record<string, Handler> = {
   },
   [GitHubEvent.ISSUES_REOPENED]: {
     pre: [],
-    action: [async () => runtime.logger.debug(null, "TODO: replace ISSUES_REOPENED handler")],
+    action: [async () => Runtime.getState().logger.debug(null, "TODO: replace ISSUES_REOPENED handler")],
     post: [],
   },
   [GitHubEvent.ISSUES_LABELED]: {

--- a/src/handlers/processors.ts
+++ b/src/handlers/processors.ts
@@ -29,7 +29,7 @@ export const processors: Record<string, Handler> = {
   },
   [GitHubEvent.ISSUES_REOPENED]: {
     pre: [],
-    action: [async () => runtime.logger.debug("TODO: replace ISSUES_REOPENED handler")],
+    action: [async () => runtime.logger.debug(null, "TODO: replace ISSUES_REOPENED handler")],
     post: [],
   },
   [GitHubEvent.ISSUES_LABELED]: {

--- a/src/handlers/processors.ts
+++ b/src/handlers/processors.ts
@@ -27,7 +27,7 @@ export const processors: Record<string, Handler> = {
   },
   [GitHubEvent.ISSUES_REOPENED]: {
     pre: [],
-    action: [async () => Runtime.getState().logger.debug(null, "TODO: replace ISSUES_REOPENED handler")],
+    action: [async () => Runtime.getState().logger.debug("TODO: replace ISSUES_REOPENED handler")],
     post: [],
   },
   [GitHubEvent.ISSUES_LABELED]: {

--- a/src/handlers/pull-request/create-devpool-pr.ts
+++ b/src/handlers/pull-request/create-devpool-pr.ts
@@ -10,12 +10,12 @@ export async function createDevPoolPR(context: Context) {
   const devPoolRepo = "devpool-directory";
 
   if (!payload.repositories_added) {
-    return logger.info("No repositories added");
+    return logger.info(context.event, "No repositories added");
   }
 
   const repository = payload.repositories_added[0];
 
-  logger.info("New Install: ", { repository: repository.full_name });
+  logger.info(context.event, "New Install: ", { repository: repository.full_name });
 
   const [owner, repo] = repository.full_name.split("/");
 
@@ -58,7 +58,7 @@ export async function createDevPoolPR(context: Context) {
     sha: mainSha,
   });
 
-  logger.info("Branch created on DevPool Directory");
+  logger.info(context.event, "Branch created on DevPool Directory");
 
   await context.event.octokit.repos.createOrUpdateFileContents({
     owner: devPoolOwner,
@@ -79,5 +79,5 @@ export async function createDevPoolPR(context: Context) {
     base: baseRef,
   });
 
-  return logger.info("Pull request created on DevPool Directory");
+  return logger.info(context.event, "Pull request created on DevPool Directory");
 }

--- a/src/handlers/pull-request/create-devpool-pr.ts
+++ b/src/handlers/pull-request/create-devpool-pr.ts
@@ -1,21 +1,19 @@
-import Runtime from "../../bindings/bot-runtime";
 import { Context, GithubContent, Payload } from "../../types";
 
 export async function createDevPoolPR(context: Context) {
-  const runtime = Runtime.getState();
-  const logger = runtime.logger;
+  const logger = context.logger;
 
   const payload = context.event.payload as Payload;
   const devPoolOwner = "ubiquity";
   const devPoolRepo = "devpool-directory";
 
   if (!payload.repositories_added) {
-    return logger.info(context.event, "No repositories added");
+    return logger.info("No repositories added");
   }
 
   const repository = payload.repositories_added[0];
 
-  logger.info(context.event, "New Install: ", { repository: repository.full_name });
+  logger.info("New Install: ", { repository: repository.full_name });
 
   const [owner, repo] = repository.full_name.split("/");
 
@@ -58,7 +56,7 @@ export async function createDevPoolPR(context: Context) {
     sha: mainSha,
   });
 
-  logger.info(context.event, "Branch created on DevPool Directory");
+  logger.info("Branch created on DevPool Directory");
 
   await context.event.octokit.repos.createOrUpdateFileContents({
     owner: devPoolOwner,
@@ -79,5 +77,5 @@ export async function createDevPoolPR(context: Context) {
     base: baseRef,
   });
 
-  return logger.info(context.event, "Pull request created on DevPool Directory");
+  return logger.info("Pull request created on DevPool Directory");
 }

--- a/src/handlers/push/check-modified-base-rate.ts
+++ b/src/handlers/push/check-modified-base-rate.ts
@@ -11,14 +11,14 @@ export async function checkModifiedBaseRate(context: Context) {
 
   // if zero sha, push is a pr change
   if (payload.before === ZERO_SHA) {
-    logger.debug("Skipping push events, not a master write");
+    logger.debug(context.event, "Skipping push events, not a master write");
   }
 
   const changes = getCommitChanges(payload.commits);
 
   // skip if empty
   if (changes && changes.length === 0) {
-    logger.debug("Skipping push events, file change empty 1");
+    logger.debug(context.event, "Skipping push events, file change empty 1");
   }
 
   // check for modified or added files and check for specified file
@@ -26,5 +26,5 @@ export async function checkModifiedBaseRate(context: Context) {
     // update base rate
     await updateBaseRate(context, BASE_RATE_FILE);
   }
-  logger.debug("Skipping push events, file change empty 2");
+  logger.debug(context.event, "Skipping push events, file change empty 2");
 }

--- a/src/handlers/push/check-modified-base-rate.ts
+++ b/src/handlers/push/check-modified-base-rate.ts
@@ -1,24 +1,22 @@
-import Runtime from "../../bindings/bot-runtime";
 import { PushPayload, Context } from "../../types";
 import { updateBaseRate } from "./update-base-rate";
 import { ZERO_SHA, getCommitChanges, BASE_RATE_FILE } from "./index";
 
 export async function checkModifiedBaseRate(context: Context) {
-  const runtime = Runtime.getState();
-  const logger = runtime.logger;
+  const logger = context.logger;
 
   const payload = context.event.payload as PushPayload;
 
   // if zero sha, push is a pr change
   if (payload.before === ZERO_SHA) {
-    logger.debug(context.event, "Skipping push events, not a master write");
+    logger.debug("Skipping push events, not a master write");
   }
 
   const changes = getCommitChanges(payload.commits);
 
   // skip if empty
   if (changes && changes.length === 0) {
-    logger.debug(context.event, "Skipping push events, file change empty 1");
+    logger.debug("Skipping push events, file change empty 1");
   }
 
   // check for modified or added files and check for specified file
@@ -26,5 +24,5 @@ export async function checkModifiedBaseRate(context: Context) {
     // update base rate
     await updateBaseRate(context, BASE_RATE_FILE);
   }
-  logger.debug(context.event, "Skipping push events, file change empty 2");
+  logger.debug("Skipping push events, file change empty 2");
 }

--- a/src/handlers/push/index.ts
+++ b/src/handlers/push/index.ts
@@ -29,7 +29,7 @@ export async function validateConfigChange(context: ProbotContext) {
   const payload = context.payload as PushPayload;
 
   if (!payload.ref.startsWith("refs/heads/")) {
-    logger.debug("Skipping push events, not a branch");
+    logger.debug(context, "Skipping push events, not a branch");
     return;
   }
 
@@ -37,7 +37,7 @@ export async function validateConfigChange(context: ProbotContext) {
 
   // skip if empty
   if (changes && changes.length === 0) {
-    logger.debug("Skipping push events, file change empty 3");
+    logger.debug(context, "Skipping push events, file change empty 3");
     return;
   }
 
@@ -47,7 +47,7 @@ export async function validateConfigChange(context: ProbotContext) {
       .filter((commit) => commit.modified.includes(BASE_RATE_FILE) || commit.added.includes(BASE_RATE_FILE))
       .reverse()[0]?.id;
     if (!commitSha) {
-      logger.debug("Skipping push events, commit sha not found");
+      logger.debug(context, "Skipping push events, commit sha not found");
       return;
     }
 
@@ -82,14 +82,14 @@ export async function validateConfigChange(context: ProbotContext) {
       }
 
       if (errorMsg) {
-        logger.info("Config validation failed!", errorMsg);
+        logger.info(context, "Config validation failed!", errorMsg);
         await createCommitComment(context, errorMsg, commitSha, BASE_RATE_FILE);
       } else {
-        logger.debug(`Config validation passed!`);
+        logger.debug(context, `Config validation passed!`);
       }
     }
   } else {
-    logger.debug(`Skipping push events, file change doesn't include config file: ${JSON.stringify(changes)}`);
+    logger.debug(context, `Skipping push events, file change doesn't include config file: ${JSON.stringify(changes)}`);
   }
 }
 

--- a/src/handlers/push/index.ts
+++ b/src/handlers/push/index.ts
@@ -29,7 +29,7 @@ export async function validateConfigChange(context: ProbotContext) {
   const payload = context.payload as PushPayload;
 
   if (!payload.ref.startsWith("refs/heads/")) {
-    logger.debug(context, "Skipping push events, not a branch");
+    logger.debug("Skipping push events, not a branch");
     return;
   }
 
@@ -37,7 +37,7 @@ export async function validateConfigChange(context: ProbotContext) {
 
   // skip if empty
   if (changes && changes.length === 0) {
-    logger.debug(context, "Skipping push events, file change empty 3");
+    logger.debug("Skipping push events, file change empty 3");
     return;
   }
 
@@ -47,7 +47,7 @@ export async function validateConfigChange(context: ProbotContext) {
       .filter((commit) => commit.modified.includes(BASE_RATE_FILE) || commit.added.includes(BASE_RATE_FILE))
       .reverse()[0]?.id;
     if (!commitSha) {
-      logger.debug(context, "Skipping push events, commit sha not found");
+      logger.debug("Skipping push events, commit sha not found");
       return;
     }
 
@@ -82,14 +82,14 @@ export async function validateConfigChange(context: ProbotContext) {
       }
 
       if (errorMsg) {
-        logger.info(context, "Config validation failed!", errorMsg);
+        logger.info("Config validation failed!", errorMsg);
         await createCommitComment(context, errorMsg, commitSha, BASE_RATE_FILE);
       } else {
-        logger.debug(context, `Config validation passed!`);
+        logger.debug(`Config validation passed!`);
       }
     }
   } else {
-    logger.debug(context, `Skipping push events, file change doesn't include config file: ${JSON.stringify(changes)}`);
+    logger.debug(`Skipping push events, file change doesn't include config file: ${JSON.stringify(changes)}`);
   }
 }
 

--- a/src/handlers/push/update-base-rate.ts
+++ b/src/handlers/push/update-base-rate.ts
@@ -17,26 +17,26 @@ export async function updateBaseRate(context: Context, filePath: string) {
   const previousFileContent = await getPreviousFileContent(context, owner, repo, branch, filePath);
 
   if (!previousFileContent) {
-    throw logger.error("Getting previous file content failed");
+    throw logger.error(context.event, "Getting previous file content failed");
   }
   const previousConfigRaw = Buffer.from(previousFileContent, "base64").toString();
   const previousConfigParsed = parseYaml(previousConfigRaw);
 
   if (!previousConfigParsed || !previousConfigParsed.payments.basePriceMultiplier) {
-    throw logger.warn("No multiplier found in previous config");
+    throw logger.warn(context.event, "No multiplier found in previous config");
   }
 
   const previousBaseRate = previousConfigParsed.payments.basePriceMultiplier;
 
   if (!previousBaseRate) {
-    throw logger.warn("No base rate found in previous config");
+    throw logger.warn(context.event, "No base rate found in previous config");
   }
 
   // fetch all labels
   const repoLabels = await listLabelsForRepo(context);
 
   if (repoLabels.length === 0) {
-    throw logger.warn("No labels on this repo");
+    throw logger.warn(context.event, "No labels on this repo");
   }
 
   return await updateLabelsFromBaseRate(context, owner, repo, repoLabels as Label[], previousBaseRate);

--- a/src/handlers/shared/pricing.ts
+++ b/src/handlers/shared/pricing.ts
@@ -19,19 +19,19 @@ export function setPrice(context: Context, timeLabel: Label, priorityLabel: Labe
   const logger = runtime.logger;
   const { labels } = context.config;
 
-  if (!timeLabel || !priorityLabel) throw logger.warn("Time or priority label is not defined");
+  if (!timeLabel || !priorityLabel) throw logger.warn(context.event, "Time or priority label is not defined");
 
   const recognizedTimeLabels = labels.time.find((configLabel) => configLabel === timeLabel.name);
-  if (!recognizedTimeLabels) throw logger.warn("Time label is not recognized");
+  if (!recognizedTimeLabels) throw logger.warn(context.event, "Time label is not recognized");
 
   const recognizedPriorityLabels = labels.priority.find((configLabel) => configLabel === priorityLabel.name);
-  if (!recognizedPriorityLabels) throw logger.warn("Priority label is not recognized");
+  if (!recognizedPriorityLabels) throw logger.warn(context.event, "Priority label is not recognized");
 
   const timeValue = calculateLabelValue(recognizedTimeLabels);
-  if (!timeValue) throw logger.warn("Time value is not defined");
+  if (!timeValue) throw logger.warn(context.event, "Time value is not defined");
 
   const priorityValue = calculateLabelValue(recognizedPriorityLabels);
-  if (!priorityValue) throw logger.warn("Priority value is not defined");
+  if (!priorityValue) throw logger.warn(context.event, "Priority value is not defined");
 
   const taskPrice = calculateTaskPrice(context, timeValue, priorityValue);
   return `Price: ${taskPrice} USD`;

--- a/src/handlers/shared/pricing.ts
+++ b/src/handlers/shared/pricing.ts
@@ -1,4 +1,3 @@
-import Runtime from "../../bindings/bot-runtime";
 import { calculateLabelValue } from "../../helpers";
 import { Label, Context } from "../../types";
 
@@ -15,23 +14,22 @@ export function calculateTaskPrice(
 }
 
 export function setPrice(context: Context, timeLabel: Label, priorityLabel: Label) {
-  const runtime = Runtime.getState();
-  const logger = runtime.logger;
+  const logger = context.logger;
   const { labels } = context.config;
 
-  if (!timeLabel || !priorityLabel) throw logger.warn(context.event, "Time or priority label is not defined");
+  if (!timeLabel || !priorityLabel) throw logger.warn("Time or priority label is not defined");
 
   const recognizedTimeLabels = labels.time.find((configLabel) => configLabel === timeLabel.name);
-  if (!recognizedTimeLabels) throw logger.warn(context.event, "Time label is not recognized");
+  if (!recognizedTimeLabels) throw logger.warn("Time label is not recognized");
 
   const recognizedPriorityLabels = labels.priority.find((configLabel) => configLabel === priorityLabel.name);
-  if (!recognizedPriorityLabels) throw logger.warn(context.event, "Priority label is not recognized");
+  if (!recognizedPriorityLabels) throw logger.warn("Priority label is not recognized");
 
   const timeValue = calculateLabelValue(recognizedTimeLabels);
-  if (!timeValue) throw logger.warn(context.event, "Time value is not defined");
+  if (!timeValue) throw logger.warn("Time value is not defined");
 
   const priorityValue = calculateLabelValue(recognizedPriorityLabels);
-  if (!priorityValue) throw logger.warn(context.event, "Priority value is not defined");
+  if (!priorityValue) throw logger.warn("Priority value is not defined");
 
   const taskPrice = calculateTaskPrice(context, timeValue, priorityValue);
   return `Price: ${taskPrice} USD`;

--- a/src/helpers/file.ts
+++ b/src/helpers/file.ts
@@ -10,8 +10,7 @@ export async function getPreviousFileContent(
   branch: string,
   filePath: string
 ) {
-  const runtime = Runtime.getState();
-  const logger = runtime.logger;
+  const logger = context.logger;
 
   try {
     // Get the latest commit of the branch
@@ -63,7 +62,7 @@ export async function getPreviousFileContent(
     }
     return null;
   } catch (error: unknown) {
-    logger.debug(context.event, "Error retrieving previous file content.", { error });
+    logger.debug("Error retrieving previous file content.", { error });
     return null;
   }
 }
@@ -122,7 +121,7 @@ export async function getFileContent(
     }
     return null;
   } catch (error: unknown) {
-    logger.debug(context, "Error retrieving file content.", { error });
+    logger.debug("Error retrieving file content.", { error });
     return null;
   }
 }

--- a/src/helpers/file.ts
+++ b/src/helpers/file.ts
@@ -63,7 +63,7 @@ export async function getPreviousFileContent(
     }
     return null;
   } catch (error: unknown) {
-    logger.debug("Error retrieving previous file content.", { error });
+    logger.debug(context.event, "Error retrieving previous file content.", { error });
     return null;
   }
 }
@@ -122,7 +122,7 @@ export async function getFileContent(
     }
     return null;
   } catch (error: unknown) {
-    logger.debug("Error retrieving file content.", { error });
+    logger.debug(context, "Error retrieving file content.", { error });
     return null;
   }
 }

--- a/src/helpers/gpt.ts
+++ b/src/helpers/gpt.ts
@@ -77,7 +77,7 @@ export async function decideContextGPT(
   const commentsRaw = await getAllIssueComments(context, issue.number, "raw");
 
   if (!comments) {
-    logger.info(`Error getting issue comments`);
+    logger.info(context.event, `Error getting issue comments`);
     return `Error getting issue comments`;
   }
 
@@ -101,7 +101,7 @@ export async function decideContextGPT(
   const links = await getAllLinkedIssuesAndPullsInBody(context, issue.number);
 
   if (typeof links === "string") {
-    return logger.info("Error getting linked issues or prs: ", { links });
+    return logger.info(context.event, "Error getting linked issues or prs: ", { links });
   }
 
   linkedIssueStreamlined = links.linkedIssues;
@@ -140,6 +140,7 @@ export async function askGPT(context: Context, chatHistory: CreateChatCompletion
 
   if (!keys.openAi) {
     throw logger.error(
+      context.event,
       "You must configure the `openai-api-key` property in the bot configuration in order to use AI powered features."
     );
   }
@@ -164,7 +165,7 @@ export async function askGPT(context: Context, chatHistory: CreateChatCompletion
   };
 
   if (!res) {
-    throw logger.error("Error getting GPT response", { res });
+    throw logger.error(context.event, "Error getting GPT response", { res });
   }
 
   return { answer, tokenUsage };

--- a/src/helpers/issue.ts
+++ b/src/helpers/issue.ts
@@ -75,7 +75,7 @@ export async function clearAllPriceLabelsOnIssue(context: Context) {
     name: issuePrices[0].name,
   });
   // } catch (e: unknown) {
-  //   runtime.logger.debug("Clearing all price labels failed!", e);
+  //   runtime.logger.debug(context.event, "Clearing all price labels failed!", e);
   // }
 }
 
@@ -84,7 +84,7 @@ export async function addLabelToIssue(context: Context, labelName: string) {
 
   const payload = context.event.payload as Payload;
   if (!payload.issue) {
-    throw runtime.logger.error("Issue object is null");
+    throw runtime.logger.error(context.event, "Issue object is null");
   }
 
   try {
@@ -95,7 +95,7 @@ export async function addLabelToIssue(context: Context, labelName: string) {
       labels: [labelName],
     });
   } catch (e: unknown) {
-    runtime.logger.debug("Adding a label to issue failed!", e);
+    runtime.logger.debug(context.event, "Adding a label to issue failed!", e);
   }
 }
 
@@ -167,7 +167,7 @@ export async function addCommentToIssue(context: Context, message: HandlerReturn
       body: comment,
     });
   } catch (e: unknown) {
-    runtime.logger.error("Adding a comment failed!", e);
+    runtime.logger.error(context.event, "Adding a comment failed!", e);
   }
 }
 
@@ -180,7 +180,7 @@ export async function upsertLastCommentToIssue(context: Context, issue_number: n
     if (comments.length > 0 && comments[comments.length - 1].body !== commentBody)
       await addCommentToIssue(context, commentBody, issue_number);
   } catch (e: unknown) {
-    runtime.logger.debug("Upserting last comment failed!", e);
+    runtime.logger.debug(context.event, "Upserting last comment failed!", e);
   }
 }
 
@@ -212,7 +212,7 @@ export async function getIssueDescription(
   }
 
   if (!result) {
-    throw runtime.logger.error("Issue description is empty");
+    throw runtime.logger.error(context.event, "Issue description is empty");
   }
 
   return result;
@@ -312,7 +312,7 @@ async function checkUserPermissionForRepo(context: Context, username: string): P
 
     return res.status === 204;
   } catch (e: unknown) {
-    runtime.logger.error("Checking if user permisson for repo failed!", e);
+    runtime.logger.error(context.event, "Checking if user permisson for repo failed!", e);
     return false;
   }
 }
@@ -331,7 +331,7 @@ async function checkUserPermissionForOrg(context: Context, username: string): Pr
     // skipping status check due to type error of checkMembershipForUser function of octokit
     return true;
   } catch (e: unknown) {
-    runtime.logger.error("Checking if user permisson for org failed!", e);
+    runtime.logger.error(context.event, "Checking if user permisson for org failed!", e);
     return false;
   }
 }
@@ -365,7 +365,7 @@ export async function isUserAdminOrBillingManager(
   async function checkIfIsBillingManager() {
     const runtime = Runtime.getState();
 
-    if (!payload.organization) throw runtime.logger.error(`No organization found in payload!`);
+    if (!payload.organization) throw runtime.logger.error(context.event, `No organization found in payload!`);
     const { data: membership } = await context.event.octokit.rest.orgs.getMembershipForUser({
       org: payload.organization.login,
       username: payload.repository.owner.login,
@@ -392,7 +392,7 @@ export async function addAssignees(context: Context, issue: number, assignees: s
       assignees,
     });
   } catch (e: unknown) {
-    runtime.logger.debug("Adding assignees failed!", e);
+    runtime.logger.debug(context.event, "Adding assignees failed!", e);
   }
 }
 
@@ -413,7 +413,7 @@ export async function deleteLabel(context: Context, label: string) {
       });
     }
   } catch (e: unknown) {
-    runtime.logger.debug("Deleting label failed!", e);
+    runtime.logger.debug(context.event, "Deleting label failed!", e);
   }
 }
 
@@ -422,7 +422,7 @@ export async function removeLabel(context: Context, name: string) {
 
   const payload = context.event.payload as Payload;
   if (!payload.issue) {
-    runtime.logger.debug("Invalid issue object");
+    runtime.logger.debug(context.event, "Invalid issue object");
     return;
   }
 
@@ -434,7 +434,7 @@ export async function removeLabel(context: Context, name: string) {
       name: name,
     });
   } catch (e: unknown) {
-    runtime.logger.debug("Removing label failed!", e);
+    runtime.logger.debug(context.event, "Removing label failed!", e);
   }
 }
 
@@ -484,7 +484,7 @@ export async function closePullRequest(context: Context, pull_number: number) {
       state: "closed",
     });
   } catch (e: unknown) {
-    runtime.logger.debug("Closing pull requests failed!", e);
+    runtime.logger.debug(context.event, "Closing pull requests failed!", e);
   }
 }
 
@@ -533,7 +533,7 @@ async function getPullRequestReviews(
     });
     return reviews;
   } catch (e: unknown) {
-    runtime.logger.debug("Fetching pull request reviews failed!", e);
+    runtime.logger.debug(context.event, "Fetching pull request reviews failed!", e);
     return [];
   }
 }
@@ -549,7 +549,7 @@ export async function getReviewRequests(context: Context, pull_number: number, o
     });
     return response.data;
   } catch (e: unknown) {
-    runtime.logger.error("Could not get requested reviewers", e);
+    runtime.logger.error(context.event, "Could not get requested reviewers", e);
     return null;
   }
 }
@@ -566,7 +566,7 @@ export async function getIssueByNumber(context: Context, issueNumber: number) {
     });
     return issue;
   } catch (e: unknown) {
-    runtime.logger.debug("Fetching issue failed!", e);
+    runtime.logger.debug(context.event, "Fetching issue failed!", e);
     return;
   }
 }
@@ -665,11 +665,11 @@ export async function getAllLinkedIssuesAndPullsInBody(context: Context, issueNu
   const issue = await getIssueByNumber(context, issueNumber);
 
   if (!issue) {
-    throw logger.error("No issue found!", { issueNumber });
+    throw logger.error(context.event, "No issue found!", { issueNumber });
   }
 
   if (!issue.body) {
-    throw logger.error("No body found!", { issueNumber });
+    throw logger.error(context.event, "No body found!", { issueNumber });
   }
 
   const body = issue.body;
@@ -698,7 +698,7 @@ export async function getAllLinkedIssuesAndPullsInBody(context: Context, issueNu
         }
       });
     } else {
-      runtime.logger.info(`No linked issues or prs found`);
+      runtime.logger.info(context.event, `No linked issues or prs found`);
     }
 
     if (linkedPrs.length > 0) {
@@ -756,7 +756,7 @@ export async function getAllLinkedIssuesAndPullsInBody(context: Context, issueNu
       linkedPrs: linkedPRStreamlined,
     };
   } else {
-    runtime.logger.info(`No matches found`);
+    runtime.logger.info(context.event, `No matches found`);
     return {
       linkedIssues: [],
       linkedPrs: [],

--- a/src/helpers/label.ts
+++ b/src/helpers/label.ts
@@ -24,7 +24,7 @@ export async function listLabelsForRepo(context: Context): Promise<Label[]> {
     return res.data;
   }
 
-  throw runtime.logger.error("Failed to fetch lists of labels", { status: res.status });
+  throw runtime.logger.error(context.event, "Failed to fetch lists of labels", { status: res.status });
 }
 
 export async function createLabel(
@@ -84,7 +84,7 @@ export async function updateLabelsFromBaseRate(
   const labelsFiltered: string[] = labels.map((obj) => obj["name"]);
   const usedLabels = uniquePreviousLabels.filter((value: string) => labelsFiltered.includes(value));
 
-  logger.debug("Got used labels: ", { usedLabels });
+  logger.debug(context.event, "Got used labels: ", { usedLabels });
 
   for (const label of usedLabels) {
     if (label.startsWith("Price: ")) {
@@ -94,7 +94,7 @@ export async function updateLabelsFromBaseRate(
       const exist = await labelExists(context, uniqueNewLabels[index]);
       if (exist) {
         // we have to delete first
-        logger.debug("Label already exists, deleting it", { label });
+        logger.debug(context.event, "Label already exists, deleting it", { label });
         await deleteLabel(context, uniqueNewLabels[index]);
       }
 
@@ -111,7 +111,7 @@ export async function updateLabelsFromBaseRate(
         },
       });
 
-      logger.debug("Label updated", { label, to: uniqueNewLabels[index] });
+      logger.debug(context.event, "Label updated", { label, to: uniqueNewLabels[index] });
     }
   }
 }

--- a/src/helpers/label.ts
+++ b/src/helpers/label.ts
@@ -1,4 +1,3 @@
-import Runtime from "../bindings/bot-runtime";
 import { labelExists } from "../handlers/pricing/pricing-label";
 import { calculateTaskPrice } from "../handlers/shared/pricing";
 import { calculateLabelValue } from "../helpers";
@@ -10,7 +9,6 @@ const COLORS = { default: "ededed", price: "1f883d" };
 // cspell:enable
 
 export async function listLabelsForRepo(context: Context): Promise<Label[]> {
-  const runtime = Runtime.getState();
   const payload = context.event.payload as Payload;
 
   const res = await context.event.octokit.rest.issues.listLabelsForRepo({
@@ -24,7 +22,7 @@ export async function listLabelsForRepo(context: Context): Promise<Label[]> {
     return res.data;
   }
 
-  throw runtime.logger.error(context.event, "Failed to fetch lists of labels", { status: res.status });
+  throw context.logger.error("Failed to fetch lists of labels", { status: res.status });
 }
 
 export async function createLabel(
@@ -49,8 +47,7 @@ export async function updateLabelsFromBaseRate(
   labels: Label[],
   previousBaseRate: number
 ) {
-  const runtime = Runtime.getState();
-  const logger = runtime.logger;
+  const logger = context.logger;
   const config = context.config;
 
   const newLabels: string[] = [];
@@ -84,7 +81,7 @@ export async function updateLabelsFromBaseRate(
   const labelsFiltered: string[] = labels.map((obj) => obj["name"]);
   const usedLabels = uniquePreviousLabels.filter((value: string) => labelsFiltered.includes(value));
 
-  logger.debug(context.event, "Got used labels: ", { usedLabels });
+  logger.debug("Got used labels: ", { usedLabels });
 
   for (const label of usedLabels) {
     if (label.startsWith("Price: ")) {
@@ -94,7 +91,7 @@ export async function updateLabelsFromBaseRate(
       const exist = await labelExists(context, uniqueNewLabels[index]);
       if (exist) {
         // we have to delete first
-        logger.debug(context.event, "Label already exists, deleting it", { label });
+        logger.debug("Label already exists, deleting it", { label });
         await deleteLabel(context, uniqueNewLabels[index]);
       }
 
@@ -111,7 +108,7 @@ export async function updateLabelsFromBaseRate(
         },
       });
 
-      logger.debug(context.event, "Label updated", { label, to: uniqueNewLabels[index] });
+      logger.debug("Label updated", { label, to: uniqueNewLabels[index] });
     }
   }
 }

--- a/src/helpers/parser.ts
+++ b/src/helpers/parser.ts
@@ -1,7 +1,6 @@
 import axios from "axios";
 import { HTMLElement, parse } from "node-html-parser";
 import { getPullByNumber } from "./issue";
-import Runtime from "../bindings/bot-runtime";
 import { Context } from "../types";
 
 interface GetLinkedParams {
@@ -36,14 +35,14 @@ export async function getLinkedPullRequests(
   context: Context,
   { owner, repository, issue }: GetLinkedParams
 ): Promise<GetLinkedResults[]> {
-  const logger = Runtime.getState().logger;
+  const logger = context.logger;
   const collection = [] as GetLinkedResults[];
   const { data } = await axios.get(`https://github.com/${owner}/${repository}/issues/${issue}`);
   const dom = parse(data);
   const devForm = dom.querySelector("[data-target='create-branch.developmentForm']") as HTMLElement;
   const linkedList = devForm.querySelectorAll(".my-1");
   if (linkedList.length === 0) {
-    logger.info(context.event, `No linked pull requests found`);
+    context.logger.info(`No linked pull requests found`);
     return [];
   }
 
@@ -62,7 +61,7 @@ export async function getLinkedPullRequests(
     const href = `https://github.com${relativeHref}`;
 
     if (`${organization}/${repository}` !== `${owner}/${repository}`) {
-      logger.info(context.event, "Skipping linked pull request from another repository", href);
+      logger.info("Skipping linked pull request from another repository", href);
       continue;
     }
 

--- a/src/helpers/parser.ts
+++ b/src/helpers/parser.ts
@@ -32,11 +32,10 @@ export async function getLinkedIssues({ owner, repository, pull }: GetLinkedPara
   return issueUrl;
 }
 
-export async function getLinkedPullRequests({
-  owner,
-  repository,
-  issue,
-}: GetLinkedParams): Promise<GetLinkedResults[]> {
+export async function getLinkedPullRequests(
+  context: Context,
+  { owner, repository, issue }: GetLinkedParams
+): Promise<GetLinkedResults[]> {
   const logger = Runtime.getState().logger;
   const collection = [] as GetLinkedResults[];
   const { data } = await axios.get(`https://github.com/${owner}/${repository}/issues/${issue}`);
@@ -44,7 +43,7 @@ export async function getLinkedPullRequests({
   const devForm = dom.querySelector("[data-target='create-branch.developmentForm']") as HTMLElement;
   const linkedList = devForm.querySelectorAll(".my-1");
   if (linkedList.length === 0) {
-    logger.info(`No linked pull requests found`);
+    logger.info(context.event, `No linked pull requests found`);
     return [];
   }
 
@@ -63,7 +62,7 @@ export async function getLinkedPullRequests({
     const href = `https://github.com${relativeHref}`;
 
     if (`${organization}/${repository}` !== `${owner}/${repository}`) {
-      logger.info("Skipping linked pull request from another repository", href);
+      logger.info(context.event, "Skipping linked pull request from another repository", href);
       continue;
     }
 

--- a/src/helpers/payout.ts
+++ b/src/helpers/payout.ts
@@ -40,8 +40,7 @@ export function getPayoutConfigByNetworkId(evmNetworkId: number) {
 }
 
 export async function hasLabelEditPermission(context: Context, label: string, caller: string) {
-  const runtime = Runtime.getState();
-  const logger = runtime.logger;
+  const logger = context.logger;
   const sufficientPrivileges = await isUserAdminOrBillingManager(context, caller);
 
   // get text before :
@@ -54,7 +53,7 @@ export async function hasLabelEditPermission(context: Context, label: string, ca
     const userId = await user.getUserId(context.event, caller);
     const accessible = await access.getAccess(userId);
     if (accessible) return true;
-    logger.info(context.event, "No access to edit label", { caller, label });
+    logger.info("No access to edit label", { caller, label });
     return false;
   }
 

--- a/src/helpers/payout.ts
+++ b/src/helpers/payout.ts
@@ -51,10 +51,10 @@ export async function hasLabelEditPermission(context: Context, label: string, ca
   if (sufficientPrivileges) {
     // check permission
     const { access, user } = Runtime.getState().adapters.supabase;
-    const userId = await user.getUserId(caller);
+    const userId = await user.getUserId(context.event, caller);
     const accessible = await access.getAccess(userId);
     if (accessible) return true;
-    logger.info("No access to edit label", { caller, label });
+    logger.info(context.event, "No access to edit label", { caller, label });
     return false;
   }
 

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -1,9 +1,13 @@
-import { Context as ProbotContext } from "probot";
-import { BotConfig } from "./";
+import { Context as ProbotContext, ProbotOctokit } from "probot";
+import { BotConfig, Payload } from "./";
 import OpenAI from "openai";
+import { Logs } from "../adapters/supabase";
 
 export interface Context {
   event: ProbotContext;
   config: BotConfig;
   openAi: OpenAI | null;
+  logger: Logs;
+  payload: Payload;
+  octokit: InstanceType<typeof ProbotOctokit>;
 }

--- a/src/utils/check-github-rate-limit.ts
+++ b/src/utils/check-github-rate-limit.ts
@@ -9,7 +9,7 @@ export async function checkRateLimitGit(headers: { "x-ratelimit-remaining"?: str
     const now = new Date();
     const timeToWait = resetTime.getTime() - now.getTime();
     const logger = Runtime.getState().logger;
-    logger.warn(null, "No remaining requests.", { resetTime, now, timeToWait });
+    logger.warn("No remaining requests.", { resetTime, now, timeToWait });
     await wait(timeToWait);
   }
   return remainingRequests;

--- a/src/utils/check-github-rate-limit.ts
+++ b/src/utils/check-github-rate-limit.ts
@@ -1,5 +1,7 @@
 import Runtime from "../bindings/bot-runtime";
+
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
 export async function checkRateLimitGit(headers: { "x-ratelimit-remaining"?: string; "x-ratelimit-reset"?: string }) {
   const remainingRequests = headers["x-ratelimit-remaining"] ? parseInt(headers["x-ratelimit-remaining"]) : 0;
   if (remainingRequests === 0) {
@@ -7,7 +9,7 @@ export async function checkRateLimitGit(headers: { "x-ratelimit-remaining"?: str
     const now = new Date();
     const timeToWait = resetTime.getTime() - now.getTime();
     const logger = Runtime.getState().logger;
-    logger.warn("No remaining requests.", { resetTime, now, timeToWait });
+    logger.warn(null, "No remaining requests.", { resetTime, now, timeToWait });
     await wait(timeToWait);
   }
   return remainingRequests;

--- a/src/utils/generate-configuration.ts
+++ b/src/utils/generate-configuration.ts
@@ -46,7 +46,7 @@ export async function generateConfiguration(context: ProbotContext): Promise<Bot
   if (!valid) {
     const errorMessage = getErrorMsg(validateBotConfig.errors as DefinedError[]);
     if (errorMessage) {
-      throw logger.error(context, "Invalid merged configuration", { errorMessage }, true);
+      throw logger.error("Invalid merged configuration", { errorMessage }, true);
     }
   }
 
@@ -55,7 +55,7 @@ export async function generateConfiguration(context: ProbotContext): Promise<Bot
     transformConfig(merged);
   } catch (err) {
     if (err instanceof Error && payload.issue?.number) {
-      throw logger.error(context, "Configuration error", { err }, true);
+      throw logger.error("Configuration error", { err }, true);
     }
   }
 
@@ -137,7 +137,7 @@ export function parseYaml(data: null | string) {
     }
   } catch (error) {
     const logger = Runtime.getState().logger;
-    logger.error(null, "Failed to parse YAML", { error });
+    logger.error("Failed to parse YAML", { error });
   }
   return null;
 }

--- a/src/utils/generate-configuration.ts
+++ b/src/utils/generate-configuration.ts
@@ -46,7 +46,7 @@ export async function generateConfiguration(context: ProbotContext): Promise<Bot
   if (!valid) {
     const errorMessage = getErrorMsg(validateBotConfig.errors as DefinedError[]);
     if (errorMessage) {
-      throw logger.error("Invalid merged configuration", { errorMessage }, true);
+      throw logger.error(context, "Invalid merged configuration", { errorMessage }, true);
     }
   }
 
@@ -55,7 +55,7 @@ export async function generateConfiguration(context: ProbotContext): Promise<Bot
     transformConfig(merged);
   } catch (err) {
     if (err instanceof Error && payload.issue?.number) {
-      throw logger.error("Configuration error", { err }, true);
+      throw logger.error(context, "Configuration error", { err }, true);
     }
   }
 
@@ -137,7 +137,7 @@ export function parseYaml(data: null | string) {
     }
   } catch (error) {
     const logger = Runtime.getState().logger;
-    logger.error("Failed to parse YAML", { error });
+    logger.error(null, "Failed to parse YAML", { error });
   }
   return null;
 }


### PR DESCRIPTION
Before adapters were initialized by passing probot's context to the constructor but this a problem when multiple events are received simultaneously...the latest event overwrote the previous adapters so if any previous events were still processing and using logger it would post under wrong repository/issue